### PR TITLE
[Hotfix] Swagger 서버 URL에 EC2 IP 추가 

### DIFF
--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/global/config/SwaggerConfig.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/global/config/SwaggerConfig.java
@@ -22,7 +22,7 @@ public class SwaggerConfig {
 						.version("v1.0"))
 				.servers(List.of(
 						new Server().url("http://localhost:8080").description("로컬 개발 서버"),
-						new Server().url("https://api-dev.dewple.com").description("개발 서버"),
+						new Server().url("http://43.203.217.86:8080").description("개발 서버"),
 						new Server().url("https://api.dewple.com").description("운영 서버")
 				));
 	}


### PR DESCRIPTION
## 📝 요약

## 🔖 변경 사항
- Swagger 서버 URL에 EC2 IP 추가   
- 현재 EC2 퍼블릭 IP(`43.203.217.86`)로 직접 접근
- 추후 도메인 구매 후 `api.dewple.com` 연결 예정 

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
