### PR TITLE
[Feat/#22] 모임 참여 API 개발

### DIFF
--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/ACTIVITY_API.md
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/ACTIVITY_API.md
@@ -344,6 +344,441 @@ HTTP 200 OK
 
 ---
 
+## 5. 모임 지원자 리스트 조회
+
+모임의 지원자(참가자) 목록을 페이지네이션으로 조회합니다.
+
+- **개인 모임**: 생성자 본인만 조회할 수 있습니다.
+- **동아리 모임**: 생성자 본인 또는 `MANAGE_ACTIVITY` 권한 보유자가 조회할 수 있습니다.
+
+### Request
+
+```
+GET /activities/{activityId}/participants?page=0&size=10
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `activityId` | Path | Long | O | 조회할 모임 ID |
+| `page` | Query | Integer | X | 페이지 번호 (기본값: 0) |
+| `size` | Query | Integer | X | 페이지 크기 (기본값: 10) |
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다.",
+  "result": {
+    "content": [
+      {
+        "participantId": 1,
+        "userId": 2,
+        "profileImg": "https://example.com/img.jpg",
+        "name": "홍길동",
+        "participantStatus": "PENDING",
+        "appliedAt": "2026-03-01T10:00:00+09:00"
+      }
+    ],
+    "page": 0,
+    "size": 10,
+    "hasNext": false
+  }
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `content` | Array | 지원자 목록 |
+| `content[].participantId` | Long | 참가자 레코드 ID |
+| `content[].userId` | Long | 사용자 ID |
+| `content[].profileImg` | String | 프로필 이미지 URL (null일 수 있음) |
+| `content[].name` | String | 이름 |
+| `content[].participantStatus` | String | 지원 상태 (`PENDING`, `APPROVED`, `REJECTED`) |
+| `content[].appliedAt` | String (ISO 8601) | 지원 일시 |
+| `page` | int | 현재 페이지 번호 |
+| `size` | int | 페이지 크기 |
+| `hasNext` | boolean | 다음 페이지 존재 여부 |
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 존재하지 않는 모임 ID 또는 삭제된 모임 |
+| 5007 | 403 | 지원자 조회 권한이 없습니다. | 조회 권한이 없는 사용자 |
+
+---
+
+## 6. 지원자 상태 변경 (확정/불가 처리)
+
+지원자의 상태를 확정(APPROVED) 또는 불가(REJECTED)로 변경합니다.
+
+- **개인 모임**: 생성자 본인만 변경할 수 있습니다.
+- **동아리 모임**: 생성자 본인 또는 `MANAGE_ACTIVITY` 권한 보유자가 변경할 수 있습니다.
+
+### Request
+
+```
+PATCH /activities/{activityId}/participants/{participantId}/status
+Content-Type: application/json
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `activityId` | Path | Long | O | 모임 ID |
+| `participantId` | Path | Long | O | 지원자(참가자) ID |
+| `participantStatus` | Body | String | O | 변경할 상태 (`APPROVED`, `REJECTED`) |
+
+```json
+{
+  "participantStatus": "APPROVED"
+}
+```
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다."
+}
+```
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 존재하지 않는 모임 ID 또는 삭제된 모임 |
+| 5008 | 404 | 해당 지원자를 찾을 수 없습니다. | 존재하지 않는 지원자 ID 또는 다른 모임의 지원자 |
+| 5009 | 403 | 지원자 관리 권한이 없습니다. | 관리 권한이 없는 사용자 |
+| 5010 | 400 | 유효하지 않은 지원 상태입니다. | PENDING으로 변경 시도 등 |
+
+---
+
+## 7. 모임 참여 응답 (참여/불참 선택)
+
+운영진이 참여 확정(APPROVED)한 지원자가 참여(CONFIRMED) 또는 불참(DECLINED)을 선택합니다.
+
+- **본인만 호출 가능**: APPROVED 상태인 지원자 본인만 요청할 수 있습니다.
+- **상태 흐름**: `PENDING → APPROVED(운영진) → CONFIRMED/DECLINED(지원자 본인)`
+
+### Request
+
+```
+PATCH /activities/{activityId}/participation
+Content-Type: application/json
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `activityId` | Path | Long | O | 모임 ID |
+| `participantStatus` | Body | String | O | 참여 응답 (`CONFIRMED`, `DECLINED`) |
+
+```json
+{
+  "participantStatus": "CONFIRMED"
+}
+```
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다."
+}
+```
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 존재하지 않는 모임 ID 또는 삭제된 모임 |
+| 5008 | 404 | 해당 지원자를 찾을 수 없습니다. | 해당 모임에 지원하지 않은 유저 |
+| 5011 | 400 | 참여 확정 상태가 아닌 지원자입니다. | APPROVED 상태가 아닌 지원자의 응답 시도 |
+| 5012 | 400 | 참여 응답은 CONFIRMED 또는 DECLINED만 가능합니다. | 잘못된 상태값 입력 |
+
+---
+
+## 8. 관심 모임 추가
+
+모임을 관심 모임으로 등록합니다. 이미 등록된 관심 모임을 다시 추가하면 에러가 반환됩니다.
+
+### Request
+
+```
+POST /activities/{activityId}/interest
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `activityId` | Path | Long | O | 관심 등록할 모임 ID |
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다."
+}
+```
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 존재하지 않는 모임 ID 또는 삭제된 모임 |
+| 5013 | 409 | 이미 관심 모임으로 등록되어 있습니다. | 이미 관심 모임으로 등록된 상태 |
+
+---
+
+## 9. 관심 모임 제거
+
+모임을 관심 모임에서 제거합니다. 관심 등록되지 않은 모임을 제거하면 에러가 반환됩니다.
+
+### Request
+
+```
+DELETE /activities/{activityId}/interest
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `activityId` | Path | Long | O | 관심 제거할 모임 ID |
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다."
+}
+```
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 존재하지 않는 모임 ID 또는 삭제된 모임 |
+| 5014 | 404 | 관심 모임으로 등록되지 않은 모임입니다. | 관심 등록되지 않은 모임을 제거 시도 |
+
+---
+
+## 10. 관심 모임 목록 조회
+
+관심 모임으로 등록한 모임 목록을 페이지네이션으로 조회합니다. 모임 목록 조회와 동일한 응답 포맷입니다.
+
+### Request
+
+```
+GET /activities/interests?page=0&size=10
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `page` | Query | Integer | X | 페이지 번호 (기본값: 0) |
+| `size` | Query | Integer | X | 페이지 크기 (기본값: 10) |
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다.",
+  "result": {
+    "content": [
+      {
+        "activityId": 1,
+        "thumbnailUrl": "https://example.com/thumb.jpg",
+        "activityType": "PERSONAL",
+        "clubName": null,
+        "name": "봄맞이 독서 모임",
+        "categoryName": "독서",
+        "regionName": "서울",
+        "participantCount": 5,
+        "capacity": 20,
+        "likeCount": 10,
+        "viewCount": 100,
+        "commentCount": 3,
+        "isLiked": true
+      }
+    ],
+    "page": 0,
+    "size": 10,
+    "hasNext": false
+  }
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `content` | Array | 관심 모임 목록 |
+| `content[].activityId` | Long | 모임 ID |
+| `content[].thumbnailUrl` | String | 썸네일 URL (null일 수 있음) |
+| `content[].activityType` | String | 모임 타입 (`PERSONAL`, `CLUB`) |
+| `content[].clubName` | String | 동아리 이름 (사설모임이면 null) |
+| `content[].name` | String | 모임 이름 |
+| `content[].categoryName` | String | 카테고리 이름 (null일 수 있음) |
+| `content[].regionName` | String | 지역 이름 (null일 수 있음) |
+| `content[].participantCount` | int | 참가 인원 |
+| `content[].capacity` | Integer | 정원 (null이면 무제한) |
+| `content[].likeCount` | int | 좋아요 수 |
+| `content[].viewCount` | int | 조회수 |
+| `content[].commentCount` | int | 댓글 수 |
+| `content[].isLiked` | boolean | 현재 사용자의 좋아요 여부 (항상 true) |
+| `page` | int | 현재 페이지 번호 |
+| `size` | int | 페이지 크기 |
+| `hasNext` | boolean | 다음 페이지 존재 여부 |
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+
+---
+
+## 11. 초대 코드 조회
+
+비공개 개인 모임의 초대 코드를 조회합니다. 모임 생성자만 조회할 수 있습니다.
+
+- **비공개 개인 모임 전용**: PUBLIC 모임이나 동아리 모임은 초대 코드가 없습니다.
+- **생성자 전용**: 모임을 생성한 본인만 초대 코드를 조회할 수 있습니다.
+
+### Request
+
+```
+GET /activities/{activityId}/invite-code
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 위치 | 타입 | 필수 | 설명 |
+|----------|------|------|------|------|
+| `activityId` | Path | Long | O | 모임 ID |
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다.",
+  "result": {
+    "inviteCode": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `inviteCode` | String | 초대 코드 (UUID 형식) |
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 존재하지 않는 모임 ID 또는 삭제된 모임 |
+| 5016 | 400 | 비공개 모임만 초대 코드를 사용할 수 있습니다. | PUBLIC 모임에서 초대 코드 조회 시도 |
+| 5017 | 403 | 초대 코드 조회 권한이 없습니다. | 생성자가 아닌 사용자의 조회 시도 |
+| 5021 | 400 | 개인 모임만 초대 코드를 사용할 수 있습니다. | 동아리 모임에서 초대 코드 조회 시도 |
+
+---
+
+## 12. 초대 코드로 모임 참여
+
+초대 코드를 사용하여 비공개 모임에 참여 신청합니다. PENDING 상태로 등록되며, 모임 생성자가 이후 APPROVED/REJECTED 처리합니다.
+
+### Request
+
+```
+POST /activities/join
+Content-Type: application/json
+Authorization: Bearer {accessToken}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `inviteCode` | String | O | 초대 코드 |
+
+```json
+{
+  "inviteCode": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Response (성공)
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+  "code": 1000,
+  "status": 200,
+  "message": "요청에 성공하였습니다."
+}
+```
+
+### 에러
+
+| 코드 | HTTP | 메시지 | 설명 |
+|------|------|--------|------|
+| 401 | 401 | Unauthorized | JWT 토큰 누락 또는 만료 |
+| 5000 | 404 | 모임을 찾을 수 없습니다. | 삭제된 모임 |
+| 5015 | 404 | 유효하지 않은 초대 코드입니다. | 존재하지 않는 초대 코드 |
+| 5018 | 409 | 이미 참가 신청한 모임입니다. | 이미 참가 신청한 상태 |
+| 5019 | 409 | 모임 정원이 가득 찼습니다. | 정원 초과 |
+| 5020 | 400 | 본인이 생성한 모임에는 참가할 수 없습니다. | 생성자 본인의 참여 시도 |
+
+---
+
 ## 공통 에러
 
 | 코드 | HTTP | 메시지 | 설명 |

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -7,6 +7,7 @@ import com.dewple.app_api_auth.api.activity.dto.CreateActivityResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityDetailResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityListResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetParticipantListResponse;
+import com.dewple.app_api_auth.api.activity.dto.RespondToParticipationRequest;
 import com.dewple.app_api_auth.api.activity.dto.UpdateParticipantStatusRequest;
 import com.dewple.app_api_auth.global.response.ApiResponse;
 import com.dewple.app_api_auth.global.response.SliceResponse;
@@ -169,6 +170,18 @@ public class ActivityController {
             @Valid @RequestBody UpdateParticipantStatusRequest request
     ) {
         activityService.updateParticipantStatus(userId, activityId, participantId, request.participantStatus());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "모임 참여 응답", description = "운영진이 참여 확정(APPROVED)한 지원자가 참여(CONFIRMED) 또는 불참(DECLINED)을 선택합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{activityId}/participation")
+    public ApiResponse<Void> respondToParticipation(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody RespondToParticipationRequest request
+    ) {
+        activityService.respondToParticipation(userId, activityId, request.participantStatus());
         return ApiResponse.ok();
     }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -7,6 +7,7 @@ import com.dewple.app_api_auth.api.activity.dto.CreateActivityResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityDetailResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityListResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetParticipantListResponse;
+import com.dewple.app_api_auth.api.activity.dto.UpdateParticipantStatusRequest;
 import com.dewple.app_api_auth.global.response.ApiResponse;
 import com.dewple.app_api_auth.global.response.SliceResponse;
 import com.dewple.app_api_auth.global.security.CurrentUserId;
@@ -156,5 +157,18 @@ public class ActivityController {
         Slice<ParticipantResult> results = activityService.getParticipantList(userId, activityId, pageable);
         Slice<GetParticipantListResponse> responseSlice = results.map(GetParticipantListResponse::from);
         return ApiResponse.ok(SliceResponse.from(responseSlice));
+    }
+
+    @Operation(summary = "모임 지원자 상태 변경", description = "지원자의 상태를 확정(APPROVED) 또는 불가(REJECTED)로 변경합니다. 개인 모임은 생성자만, 동아리 모임은 생성자 또는 MANAGE_ACTIVITY 권한 보유자가 변경할 수 있습니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{activityId}/participants/{participantId}/status")
+    public ApiResponse<Void> updateParticipantStatus(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long participantId,
+            @Valid @RequestBody UpdateParticipantStatusRequest request
+    ) {
+        activityService.updateParticipantStatus(userId, activityId, participantId, request.participantStatus());
+        return ApiResponse.ok();
     }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -6,7 +6,9 @@ import com.dewple.app_api_auth.api.activity.dto.CreateActivityRequest;
 import com.dewple.app_api_auth.api.activity.dto.CreateActivityResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityDetailResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityListResponse;
+import com.dewple.app_api_auth.api.activity.dto.GetInviteCodeResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetParticipantListResponse;
+import com.dewple.app_api_auth.api.activity.dto.JoinByInviteCodeRequest;
 import com.dewple.app_api_auth.api.activity.dto.RespondToParticipationRequest;
 import com.dewple.app_api_auth.api.activity.dto.UpdateParticipantStatusRequest;
 import com.dewple.app_api_auth.global.response.ApiResponse;
@@ -217,5 +219,27 @@ public class ActivityController {
         Slice<ActivitySummaryResult> results = activityService.getInterestedActivities(userId, pageable);
         Slice<GetActivityListResponse> responseSlice = results.map(GetActivityListResponse::from);
         return ApiResponse.ok(SliceResponse.from(responseSlice));
+    }
+
+    @Operation(summary = "초대 코드 조회", description = "비공개 개인 모임의 초대 코드를 조회합니다. 모임 생성자만 조회할 수 있습니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/{activityId}/invite-code")
+    public ApiResponse<GetInviteCodeResponse> getInviteCode(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        String inviteCode = activityService.getInviteCode(userId, activityId);
+        return ApiResponse.ok(new GetInviteCodeResponse(inviteCode));
+    }
+
+    @Operation(summary = "초대 코드로 모임 참여", description = "초대 코드를 사용하여 비공개 모임에 참여 신청합니다. PENDING 상태로 등록됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/join")
+    public ApiResponse<Void> joinByInviteCode(
+            @CurrentUserId Long userId,
+            @Valid @RequestBody JoinByInviteCodeRequest request
+    ) {
+        activityService.joinByInviteCode(userId, request.inviteCode());
+        return ApiResponse.ok();
     }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -6,6 +6,7 @@ import com.dewple.app_api_auth.api.activity.dto.CreateActivityRequest;
 import com.dewple.app_api_auth.api.activity.dto.CreateActivityResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityDetailResponse;
 import com.dewple.app_api_auth.api.activity.dto.GetActivityListResponse;
+import com.dewple.app_api_auth.api.activity.dto.GetParticipantListResponse;
 import com.dewple.app_api_auth.global.response.ApiResponse;
 import com.dewple.app_api_auth.global.response.SliceResponse;
 import com.dewple.app_api_auth.global.security.CurrentUserId;
@@ -16,6 +17,7 @@ import com.dewple.activity.service.CreateActivityParam;
 import com.dewple.activity.service.CreateActivityResult;
 import com.dewple.activity.service.GetActivityDetailResult;
 import com.dewple.activity.service.GetActivityListParam;
+import com.dewple.activity.service.ParticipantResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -141,5 +143,18 @@ public class ActivityController {
                 result.endAt(),
                 participants
         ));
+    }
+
+    @Operation(summary = "모임 지원자 리스트 조회", description = "모임의 지원자 목록을 조회합니다. 개인 모임은 생성자만, 동아리 모임은 생성자 또는 MANAGE_ACTIVITY 권한 보유자가 조회할 수 있습니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/{activityId}/participants")
+    public ApiResponse<SliceResponse<GetParticipantListResponse>> getParticipantList(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Slice<ParticipantResult> results = activityService.getParticipantList(userId, activityId, pageable);
+        Slice<GetParticipantListResponse> responseSlice = results.map(GetParticipantListResponse::from);
+        return ApiResponse.ok(SliceResponse.from(responseSlice));
     }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -184,4 +184,38 @@ public class ActivityController {
         activityService.respondToParticipation(userId, activityId, request.participantStatus());
         return ApiResponse.ok();
     }
+
+    @Operation(summary = "관심 모임 추가", description = "모임을 관심 모임으로 등록합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{activityId}/interest")
+    public ApiResponse<Void> addActivityInterest(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.addActivityInterest(userId, activityId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "관심 모임 제거", description = "모임을 관심 모임에서 제거합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{activityId}/interest")
+    public ApiResponse<Void> removeActivityInterest(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.removeActivityInterest(userId, activityId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "관심 모임 목록 조회", description = "관심 모임으로 등록한 모임 목록을 조회합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/interests")
+    public ApiResponse<SliceResponse<GetActivityListResponse>> getInterestedActivities(
+            @CurrentUserId Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Slice<ActivitySummaryResult> results = activityService.getInterestedActivities(userId, pageable);
+        Slice<GetActivityListResponse> responseSlice = results.map(GetActivityListResponse::from);
+        return ApiResponse.ok(SliceResponse.from(responseSlice));
+    }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/GetInviteCodeResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/GetInviteCodeResponse.java
@@ -1,0 +1,9 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "초대 코드 조회 응답")
+public record GetInviteCodeResponse(
+        @Schema(description = "초대 코드") String inviteCode
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/GetParticipantListResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/GetParticipantListResponse.java
@@ -1,0 +1,39 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import com.dewple.activity.service.ParticipantResult;
+import com.dewple.common.enums.ParticipantStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "지원자 목록 응답")
+public record GetParticipantListResponse(
+        @Schema(description = "참가자 ID", example = "1")
+        Long participantId,
+
+        @Schema(description = "사용자 ID", example = "2")
+        Long userId,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/img.jpg")
+        String profileImg,
+
+        @Schema(description = "이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "지원 상태", example = "PENDING")
+        ParticipantStatus participantStatus,
+
+        @Schema(description = "지원 일시", example = "2026-03-01T10:00:00+09:00")
+        OffsetDateTime appliedAt
+) {
+    public static GetParticipantListResponse from(ParticipantResult result) {
+        return new GetParticipantListResponse(
+                result.participantId(),
+                result.userId(),
+                result.profileImg(),
+                result.name(),
+                result.participantStatus(),
+                result.appliedAt()
+        );
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/GetParticipantListResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/GetParticipantListResponse.java
@@ -8,7 +8,7 @@ import java.time.OffsetDateTime;
 
 @Schema(description = "지원자 목록 응답")
 public record GetParticipantListResponse(
-        @Schema(description = "참가자 ID", example = "1")
+        @Schema(description = "지원자 ID", example = "1")
         Long participantId,
 
         @Schema(description = "사용자 ID", example = "2")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/JoinByInviteCodeRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/JoinByInviteCodeRequest.java
@@ -1,0 +1,11 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "초대 코드로 모임 참여 요청")
+public record JoinByInviteCodeRequest(
+        @Schema(description = "초대 코드")
+        @NotBlank(message = "초대 코드는 필수입니다.") String inviteCode
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/RespondToParticipationRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/RespondToParticipationRequest.java
@@ -1,0 +1,13 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import com.dewple.common.enums.ParticipantStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "모임 참여 응답 요청")
+public record RespondToParticipationRequest(
+        @Schema(description = "참여 응답 (CONFIRMED: 참여, DECLINED: 불참)", example = "CONFIRMED")
+        @NotNull(message = "참여 응답은 필수입니다.")
+        ParticipantStatus participantStatus
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/UpdateParticipantStatusRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/UpdateParticipantStatusRequest.java
@@ -1,0 +1,13 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import com.dewple.common.enums.ParticipantStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "모임 지원자 상태 변경 요청")
+public record UpdateParticipantStatusRequest(
+        @Schema(description = "변경할 상태 (APPROVED: 확정, REJECTED: 불가)", example = "APPROVED")
+        @NotNull(message = "지원 상태는 필수입니다.")
+        ParticipantStatus participantStatus
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/global/security/CurrentUserId.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/global/security/CurrentUserId.java
@@ -1,5 +1,7 @@
 package com.dewple.app_api_auth.global.security;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +9,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface CurrentUserId {
 }

--- a/apps/app-api-auth/src/main/resources/db/migration/V2__add_participant_status_to_activity_participant.sql
+++ b/apps/app-api-auth/src/main/resources/db/migration/V2__add_participant_status_to_activity_participant.sql
@@ -1,0 +1,2 @@
+ALTER TABLE activity_participant
+    ADD COLUMN participant_status VARCHAR(20) NOT NULL DEFAULT 'PENDING';

--- a/apps/app-api-auth/src/main/resources/db/migration/V3__add_invite_code_to_activity.sql
+++ b/apps/app-api-auth/src/main/resources/db/migration/V3__add_invite_code_to_activity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE activity
+    ADD COLUMN invite_code VARCHAR(36) UNIQUE;

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -980,4 +980,80 @@ class ActivityControllerTest {
                     .andExpect(status().isUnauthorized());
         }
     }
+
+    @Nested
+    @DisplayName("GET /activities/{activityId}/invite-code - 초대 코드 조회")
+    class GetInviteCode {
+
+        @Test
+        @DisplayName("성공: 초대 코드 조회")
+        void success() throws Exception {
+            // given
+            given(activityService.getInviteCode(1L, 100L)).willReturn("test-invite-code-uuid");
+
+            // when & then
+            mockMvc.perform(get("/activities/{activityId}/invite-code", 100L)
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.inviteCode").value("test-invite-code-uuid"));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(get("/activities/{activityId}/invite-code", 100L))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /activities/join - 초대 코드로 모임 참여")
+    class JoinByInviteCode {
+
+        @Test
+        @DisplayName("성공: 초대 코드로 모임 참여")
+        void success() throws Exception {
+            // when & then
+            mockMvc.perform(post("/activities/join")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("inviteCode", "test-invite-code"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(post("/activities/join")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("inviteCode", "test-invite-code"))))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: inviteCode 누락")
+        void failMissingInviteCode() throws Exception {
+            // when & then
+            mockMvc.perform(post("/activities/join")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: inviteCode 빈 문자열")
+        void failEmptyInviteCode() throws Exception {
+            // when & then
+            mockMvc.perform(post("/activities/join")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("inviteCode", ""))))
+                    .andExpect(status().isBadRequest());
+        }
+    }
 }

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -43,6 +43,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -745,6 +746,116 @@ class ActivityControllerTest {
                             .with(jwt().jwt(j -> j.subject("1"))))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value(5007));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /activities/{activityId}/participants/{participantId}/status - 지원자 상태 변경")
+    class UpdateParticipantStatus {
+
+        @Test
+        @DisplayName("성공: 지원자 확정")
+        void successApprove() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 100L, 1L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "APPROVED"
+                            ))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("성공: 지원자 거절")
+        void successReject() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 100L, 1L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "REJECTED"
+                            ))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 100L, 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "APPROVED"
+                            ))))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: participantStatus 누락")
+        void failWithMissingStatus() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 100L, 1L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음 (서비스 예외)")
+        void failWithActivityNotFound() throws Exception {
+            // given
+            willThrow(new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND))
+                    .given(activityService).updateParticipantStatus(eq(1L), eq(999L), eq(1L), any());
+
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 999L, 1L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "APPROVED"
+                            ))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(5000));
+        }
+
+        @Test
+        @DisplayName("실패: 관리 권한 없음 (서비스 예외)")
+        void failWithPermissionDenied() throws Exception {
+            // given
+            willThrow(new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED))
+                    .given(activityService).updateParticipantStatus(eq(1L), eq(100L), eq(1L), any());
+
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 100L, 1L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "APPROVED"
+                            ))))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value(5009));
+        }
+
+        @Test
+        @DisplayName("실패: 지원자 없음 (서비스 예외)")
+        void failWithParticipantNotFound() throws Exception {
+            // given
+            willThrow(new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_FOUND))
+                    .given(activityService).updateParticipantStatus(eq(1L), eq(100L), eq(999L), any());
+
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participants/{participantId}/status", 100L, 999L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "APPROVED"
+                            ))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(5008));
         }
     }
 }

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -1,7 +1,6 @@
 package com.dewple.app_api_auth.api.activity.controller;
 
 import com.dewple.activity.exception.ActivityErrorCode;
-import com.dewple.activity.service.ActivityListSection;
 import com.dewple.activity.service.ActivityService;
 import com.dewple.activity.service.ActivitySummaryResult;
 import com.dewple.activity.service.CreateActivityResult;

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -858,4 +858,46 @@ class ActivityControllerTest {
                     .andExpect(jsonPath("$.code").value(5008));
         }
     }
+
+    @Nested
+    @DisplayName("PATCH /activities/{activityId}/participation - 모임 참여 응답")
+    class RespondToParticipation {
+
+        @Test
+        @DisplayName("성공: 참여 응답")
+        void successRespondToParticipation() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participation", 100L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "CONFIRMED"
+                            ))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participation", 100L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "participantStatus", "CONFIRMED"
+                            ))))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: participantStatus 누락")
+        void failWithMissingStatus() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/activities/{activityId}/participation", 100L)
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
 }

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -6,11 +6,13 @@ import com.dewple.activity.service.ActivityService;
 import com.dewple.activity.service.ActivitySummaryResult;
 import com.dewple.activity.service.CreateActivityResult;
 import com.dewple.activity.service.GetActivityDetailResult;
+import com.dewple.activity.service.ParticipantResult;
 import com.dewple.app_api_auth.global.config.SecurityConfig;
 import com.dewple.club.exception.ClubErrorCode;
 import com.dewple.common.enums.ActivityType;
 import com.dewple.common.enums.Gender;
 import com.dewple.common.enums.OpenType;
+import com.dewple.common.enums.ParticipantStatus;
 import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,6 +27,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
 
@@ -668,6 +671,80 @@ class ActivityControllerTest {
                             .with(jwt().jwt(j -> j.subject("1"))))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(5000));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /activities/{activityId}/participants - 지원자 리스트 조회")
+    class GetParticipantList {
+
+        @Test
+        @DisplayName("성공: 지원자 리스트 조회")
+        void successGetParticipantList() throws Exception {
+            // given
+            List<ParticipantResult> content = List.of(
+                    new ParticipantResult(1L, 2L, "img.jpg", "홍길동", ParticipantStatus.PENDING,
+                            OffsetDateTime.parse("2026-03-01T10:00:00+09:00")),
+                    new ParticipantResult(2L, 3L, null, "김철수", ParticipantStatus.APPROVED,
+                            OffsetDateTime.parse("2026-03-02T10:00:00+09:00"))
+            );
+            var slice = new SliceImpl<>(content, PageRequest.of(0, 10), false);
+
+            given(activityService.getParticipantList(eq(1L), eq(100L), any(Pageable.class))).willReturn(slice);
+
+            // when & then
+            mockMvc.perform(get("/activities/{activityId}/participants", 100L)
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.content").isArray())
+                    .andExpect(jsonPath("$.result.content.length()").value(2))
+                    .andExpect(jsonPath("$.result.content[0].participantId").value(1))
+                    .andExpect(jsonPath("$.result.content[0].userId").value(2))
+                    .andExpect(jsonPath("$.result.content[0].profileImg").value("img.jpg"))
+                    .andExpect(jsonPath("$.result.content[0].name").value("홍길동"))
+                    .andExpect(jsonPath("$.result.content[0].participantStatus").value("PENDING"))
+                    .andExpect(jsonPath("$.result.content[1].participantId").value(2))
+                    .andExpect(jsonPath("$.result.content[1].participantStatus").value("APPROVED"))
+                    .andExpect(jsonPath("$.result.page").value(0))
+                    .andExpect(jsonPath("$.result.size").value(10))
+                    .andExpect(jsonPath("$.result.hasNext").value(false));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(get("/activities/{activityId}/participants", 100L))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음 (서비스 예외)")
+        void failWithActivityNotFound() throws Exception {
+            // given
+            given(activityService.getParticipantList(eq(1L), eq(999L), any(Pageable.class)))
+                    .willThrow(new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/activities/{activityId}/participants", 999L)
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(5000));
+        }
+
+        @Test
+        @DisplayName("실패: 조회 권한 없음 (서비스 예외)")
+        void failWithPermissionDenied() throws Exception {
+            // given
+            given(activityService.getParticipantList(eq(1L), eq(100L), any(Pageable.class)))
+                    .willThrow(new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED));
+
+            // when & then
+            mockMvc.perform(get("/activities/{activityId}/participants", 100L)
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value(5007));
         }
     }
 }

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -900,4 +900,84 @@ class ActivityControllerTest {
                     .andExpect(status().isBadRequest());
         }
     }
+
+    @Nested
+    @DisplayName("POST /activities/{activityId}/interest - 관심 모임 추가")
+    class AddActivityInterest {
+
+        @Test
+        @DisplayName("성공: 관심 모임 추가")
+        void successAddInterest() throws Exception {
+            // when & then
+            mockMvc.perform(post("/activities/{activityId}/interest", 100L)
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(post("/activities/{activityId}/interest", 100L))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /activities/{activityId}/interest - 관심 모임 제거")
+    class RemoveActivityInterest {
+
+        @Test
+        @DisplayName("성공: 관심 모임 제거")
+        void successRemoveInterest() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/activities/{activityId}/interest", 100L)
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/activities/{activityId}/interest", 100L))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /activities/interests - 관심 모임 목록 조회")
+    class GetInterestedActivities {
+
+        @Test
+        @DisplayName("성공: 관심 모임 목록 조회")
+        void successGetInterestedActivities() throws Exception {
+            // given
+            List<ActivitySummaryResult> content = List.of(
+                    new ActivitySummaryResult(1L, "thumb.jpg", "PERSONAL", null, "관심 모임",
+                            "카테고리", "서울", 5, 20, 10, 100, 3, true)
+            );
+            given(activityService.getInterestedActivities(eq(1L), any(Pageable.class)))
+                    .willReturn(new SliceImpl<>(content, PageRequest.of(0, 10), false));
+
+            // when & then
+            mockMvc.perform(get("/activities/interests")
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.content").isArray())
+                    .andExpect(jsonPath("$.result.content[0].name").value("관심 모임"))
+                    .andExpect(jsonPath("$.result.content[0].isLiked").value(true));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void failWithoutAuthentication() throws Exception {
+            // when & then
+            mockMvc.perform(get("/activities/interests"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
@@ -123,4 +123,14 @@ public class Activity extends BaseEntity {
         this.gender = gender != null ? gender : Gender.ANY;
         this.thumbnailUrl = thumbnailUrl;
     }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
@@ -97,13 +97,16 @@ public class Activity extends BaseEntity {
     @Column(name = "comment_count", nullable = false)
     private int commentCount = 0;
 
+    @Column(name = "invite_code", length = 36, unique = true)
+    private String inviteCode;
+
     @Builder
     public Activity(Club club, User creator, OpenType openType, String name,
                     String description, Integer capacity, Boolean isAttendanceCheck,
                     Boolean isSearchable, OffsetDateTime startAt, OffsetDateTime endAt,
                     Category category, Region region, ActivityType activityType,
                     Boolean isVerificationRequired, Integer minAge, Integer maxAge,
-                    Gender gender, String thumbnailUrl) {
+                    Gender gender, String thumbnailUrl, String inviteCode) {
         this.club = club;
         this.creator = creator;
         this.openType = openType;
@@ -122,6 +125,7 @@ public class Activity extends BaseEntity {
         this.maxAge = maxAge;
         this.gender = gender != null ? gender : Gender.ANY;
         this.thumbnailUrl = thumbnailUrl;
+        this.inviteCode = inviteCode;
     }
 
     public void increaseLikeCount() {

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
@@ -44,4 +44,8 @@ public class ActivityParticipant extends BaseEntity {
         this.participantStatus = participantStatus != null ? participantStatus : ParticipantStatus.PENDING;
         this.isSettlementCompleted = isSettlementCompleted;
     }
+
+    public void updateParticipantStatus(ParticipantStatus participantStatus) {
+        this.participantStatus = participantStatus;
+    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import com.dewple.common.entity.User;
 import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.enums.ParticipantStatus;
 
 @Entity
 @Table(name = "activity_participant", uniqueConstraints = {
@@ -29,13 +30,18 @@ public class ActivityParticipant extends BaseEntity {
     @JoinColumn(name = "participant_id", nullable = false)
     private User participant;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "participant_status", nullable = false, length = 20)
+    private ParticipantStatus participantStatus = ParticipantStatus.PENDING;
+
     @Column(name = "is_settlement_completed")
     private Boolean isSettlementCompleted;
 
     @Builder
-    public ActivityParticipant(Activity activity, User participant, Boolean isSettlementCompleted) {
+    public ActivityParticipant(Activity activity, User participant, ParticipantStatus participantStatus, Boolean isSettlementCompleted) {
         this.activity = activity;
         this.participant = participant;
+        this.participantStatus = participantStatus != null ? participantStatus : ParticipantStatus.PENDING;
         this.isSettlementCompleted = isSettlementCompleted;
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -23,6 +23,8 @@ public enum ActivityErrorCode implements ErrorCode {
     INVALID_PARTICIPANT_STATUS(5010, HttpStatus.BAD_REQUEST, "유효하지 않은 지원 상태입니다."),
     PARTICIPANT_NOT_APPROVED(5011, HttpStatus.BAD_REQUEST, "참여 확정 상태가 아닌 지원자입니다."),
     INVALID_PARTICIPATION_RESPONSE(5012, HttpStatus.BAD_REQUEST, "참여 응답은 CONFIRMED 또는 DECLINED만 가능합니다."),
+    ACTIVITY_INTEREST_ALREADY_EXISTS(5013, HttpStatus.CONFLICT, "이미 관심 모임으로 등록되어 있습니다."),
+    ACTIVITY_INTEREST_NOT_FOUND(5014, HttpStatus.NOT_FOUND, "관심 모임으로 등록되지 않은 모임입니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -18,6 +18,9 @@ public enum ActivityErrorCode implements ErrorCode {
     CATEGORY_NOT_FOUND(5005, HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
     REGION_NOT_FOUND(5006, HttpStatus.NOT_FOUND, "지역을 찾을 수 없습니다."),
     ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED(5007, HttpStatus.FORBIDDEN, "지원자 조회 권한이 없습니다."),
+    PARTICIPANT_NOT_FOUND(5008, HttpStatus.NOT_FOUND, "해당 지원자를 찾을 수 없습니다."),
+    ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED(5009, HttpStatus.FORBIDDEN, "지원자 관리 권한이 없습니다."),
+    INVALID_PARTICIPANT_STATUS(5010, HttpStatus.BAD_REQUEST, "유효하지 않은 지원 상태입니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -21,6 +21,8 @@ public enum ActivityErrorCode implements ErrorCode {
     PARTICIPANT_NOT_FOUND(5008, HttpStatus.NOT_FOUND, "해당 지원자를 찾을 수 없습니다."),
     ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED(5009, HttpStatus.FORBIDDEN, "지원자 관리 권한이 없습니다."),
     INVALID_PARTICIPANT_STATUS(5010, HttpStatus.BAD_REQUEST, "유효하지 않은 지원 상태입니다."),
+    PARTICIPANT_NOT_APPROVED(5011, HttpStatus.BAD_REQUEST, "참여 확정 상태가 아닌 지원자입니다."),
+    INVALID_PARTICIPATION_RESPONSE(5012, HttpStatus.BAD_REQUEST, "참여 응답은 CONFIRMED 또는 DECLINED만 가능합니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -17,6 +17,7 @@ public enum ActivityErrorCode implements ErrorCode {
     ACTIVITY_DELETE_PERMISSION_DENIED(5004, HttpStatus.FORBIDDEN, "모임 삭제 권한이 없습니다."),
     CATEGORY_NOT_FOUND(5005, HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
     REGION_NOT_FOUND(5006, HttpStatus.NOT_FOUND, "지역을 찾을 수 없습니다."),
+    ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED(5007, HttpStatus.FORBIDDEN, "지원자 조회 권한이 없습니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -25,6 +25,13 @@ public enum ActivityErrorCode implements ErrorCode {
     INVALID_PARTICIPATION_RESPONSE(5012, HttpStatus.BAD_REQUEST, "참여 응답은 CONFIRMED 또는 DECLINED만 가능합니다."),
     ACTIVITY_INTEREST_ALREADY_EXISTS(5013, HttpStatus.CONFLICT, "이미 관심 모임으로 등록되어 있습니다."),
     ACTIVITY_INTEREST_NOT_FOUND(5014, HttpStatus.NOT_FOUND, "관심 모임으로 등록되지 않은 모임입니다."),
+    INVITE_CODE_NOT_FOUND(5015, HttpStatus.NOT_FOUND, "유효하지 않은 초대 코드입니다."),
+    ACTIVITY_NOT_PRIVATE(5016, HttpStatus.BAD_REQUEST, "비공개 모임만 초대 코드를 사용할 수 있습니다."),
+    ACTIVITY_INVITE_PERMISSION_DENIED(5017, HttpStatus.FORBIDDEN, "초대 코드 조회 권한이 없습니다."),
+    ALREADY_PARTICIPANT(5018, HttpStatus.CONFLICT, "이미 참가 신청한 모임입니다."),
+    ACTIVITY_FULL(5019, HttpStatus.CONFLICT, "모임 정원이 가득 찼습니다."),
+    CANNOT_JOIN_OWN_ACTIVITY(5020, HttpStatus.BAD_REQUEST, "본인이 생성한 모임에는 참가할 수 없습니다."),
+    ACTIVITY_NOT_USER_CREATED(5021, HttpStatus.BAD_REQUEST, "개인 모임만 초대 코드를 사용할 수 있습니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityInterestRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityInterestRepository.java
@@ -3,5 +3,9 @@ package com.dewple.activity.repository;
 import com.dewple.activity.entity.ActivityInterest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ActivityInterestRepository extends JpaRepository<ActivityInterest, Long> {
+
+    Optional<ActivityInterest> findByActivityIdAndUserId(Long activityId, Long userId);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
@@ -3,6 +3,9 @@ package com.dewple.activity.repository;
 import com.dewple.activity.entity.ActivityParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantStatus;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -11,4 +14,6 @@ public interface ActivityParticipantRepository extends JpaRepository<ActivityPar
     List<ActivityParticipant> findByActivityId(Long activityId);
 
     Optional<ActivityParticipant> findByActivityIdAndParticipantId(Long activityId, Long participantId);
+
+    long countByActivityIdAndStatusAndParticipantStatusIn(Long activityId, BaseStatus status, List<ParticipantStatus> participantStatuses);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
@@ -4,8 +4,11 @@ import com.dewple.activity.entity.ActivityParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ActivityParticipantRepository extends JpaRepository<ActivityParticipant, Long>, ActivityParticipantRepositoryCustom {
 
     List<ActivityParticipant> findByActivityId(Long activityId);
+
+    Optional<ActivityParticipant> findByActivityIdAndParticipantId(Long activityId, Long participantId);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryCustom.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.dewple.activity.repository;
 
 import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.service.ParticipantResult;
 import com.dewple.common.enums.BaseStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 public interface ActivityParticipantRepositoryCustom {
 
     List<ActivityParticipant> findByActivityIdAndStatusWithParticipant(Long activityId, BaseStatus status);
+
+    Slice<ParticipantResult> findParticipantListByActivityId(Long activityId, Pageable pageable);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryImpl.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryImpl.java
@@ -2,9 +2,14 @@ package com.dewple.activity.repository;
 
 import com.dewple.activity.entity.ActivityParticipant;
 import com.dewple.activity.entity.QActivityParticipant;
+import com.dewple.activity.service.ParticipantResult;
 import com.dewple.common.enums.BaseStatus;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
@@ -25,5 +30,35 @@ public class ActivityParticipantRepositoryImpl implements ActivityParticipantRep
                         activityParticipant.status.eq(status)
                 )
                 .fetch();
+    }
+
+    @Override
+    public Slice<ParticipantResult> findParticipantListByActivityId(Long activityId, Pageable pageable) {
+        List<ParticipantResult> content = queryFactory
+                .select(Projections.constructor(ParticipantResult.class,
+                        activityParticipant.id,
+                        activityParticipant.participant.id,
+                        activityParticipant.participant.profileImg,
+                        activityParticipant.participant.name,
+                        activityParticipant.participantStatus,
+                        activityParticipant.createdAt
+                ))
+                .from(activityParticipant)
+                .join(activityParticipant.participant)
+                .where(
+                        activityParticipant.activity.id.eq(activityId),
+                        activityParticipant.status.eq(BaseStatus.ACTIVE)
+                )
+                .orderBy(activityParticipant.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content = content.subList(0, pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
@@ -3,5 +3,9 @@ package com.dewple.activity.repository;
 import com.dewple.activity.entity.Activity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ActivityRepository extends JpaRepository<Activity, Long>, ActivityRepositoryCustom {
+
+    Optional<Activity> findByInviteCode(String inviteCode);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepositoryCustom.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface ActivityRepositoryCustom {
     Slice<ActivitySummaryResult> findActivitiesByLikedClubs(Long userId, Pageable pageable);
 
     Slice<ActivitySummaryResult> findActivitiesByMyClubs(Long userId, Pageable pageable);
+
+    Slice<ActivitySummaryResult> findInterestedActivities(Long userId, Pageable pageable);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepositoryCustom.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepositoryCustom.java
@@ -4,8 +4,6 @@ import com.dewple.activity.service.ActivitySummaryResult;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.List;
-
 public interface ActivityRepositoryCustom {
 
     Slice<ActivitySummaryResult> findPersonalActivities(Long userId, Pageable pageable);

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepositoryImpl.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepositoryImpl.java
@@ -61,6 +61,19 @@ public class ActivityRepositoryImpl implements ActivityRepositoryCustom {
         return findActivities(userId, condition, pageable);
     }
 
+    @Override
+    public Slice<ActivitySummaryResult> findInterestedActivities(Long userId, Pageable pageable) {
+        BooleanExpression condition = activity.id.in(
+                JPAExpressions.select(activityInterest.activity.id)
+                        .from(activityInterest)
+                        .where(
+                                activityInterest.user.id.eq(userId),
+                                activityInterest.status.eq(BaseStatus.ACTIVE)
+                        )
+        );
+        return findActivities(userId, condition, pageable);
+    }
+
     private Slice<ActivitySummaryResult> findActivities(Long userId, BooleanExpression sectionCondition, Pageable pageable) {
         QActivityParticipant subParticipant = new QActivityParticipant("subParticipant");
 

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -21,6 +21,7 @@ import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -206,5 +207,34 @@ public class ActivityService {
             case LIKED_CLUBS -> activityRepository.findActivitiesByLikedClubs(userId, param.pageable());
             case MY_CLUBS -> activityRepository.findActivitiesByMyClubs(userId, param.pageable());
         };
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ParticipantResult> getParticipantList(Long userId, Long activityId, Pageable pageable) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        boolean isCreator = activity.getCreator().getId().equals(userId);
+
+        if (activity.getClub() != null) {
+            if (!isCreator) {
+                ClubMember member = clubMemberRepository.findByClubIdAndUserId(activity.getClub().getId(), userId)
+                        .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED));
+
+                if (member.getRole() == null || !member.getRole().hasPermission(Permission.MANAGE_ACTIVITY)) {
+                    throw new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED);
+                }
+            }
+        } else {
+            if (!isCreator) {
+                throw new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED);
+            }
+        }
+
+        return activityParticipantRepository.findParticipantListByActivityId(activityId, pageable);
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -30,9 +30,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.OpenType;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -86,6 +88,11 @@ public class ActivityService {
                     .orElseThrow(() -> new BusinessException(ActivityErrorCode.REGION_NOT_FOUND));
         }
 
+        String inviteCode = null;
+        if (param.openType() == OpenType.PRIVATE && param.clubId() == null) {
+            inviteCode = UUID.randomUUID().toString();
+        }
+
         Activity activity = Activity.builder()
                 .club(club)
                 .creator(creator)
@@ -104,6 +111,7 @@ public class ActivityService {
                 .minAge(param.minAge())
                 .maxAge(param.maxAge())
                 .gender(param.gender())
+                .inviteCode(inviteCode)
                 .build();
 
         activityRepository.save(activity);
@@ -360,5 +368,71 @@ public class ActivityService {
     @Transactional(readOnly = true)
     public Slice<ActivitySummaryResult> getInterestedActivities(Long userId, Pageable pageable) {
         return activityRepository.findInterestedActivities(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public String getInviteCode(Long userId, Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        if (activity.getOpenType() != OpenType.PRIVATE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_PRIVATE);
+        }
+
+        if (activity.getClub() != null) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_USER_CREATED);
+        }
+
+        if (!activity.getCreator().getId().equals(userId)) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_INVITE_PERMISSION_DENIED);
+        }
+
+        return activity.getInviteCode();
+    }
+
+    @Transactional
+    public void joinByInviteCode(Long userId, String inviteCode) {
+        Activity activity = activityRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.INVITE_CODE_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        if (activity.getCreator().getId().equals(userId)) {
+            throw new BusinessException(ActivityErrorCode.CANNOT_JOIN_OWN_ACTIVITY);
+        }
+
+        activityParticipantRepository.findByActivityIdAndParticipantId(activity.getId(), userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .ifPresent(p -> {
+                    throw new BusinessException(ActivityErrorCode.ALREADY_PARTICIPANT);
+                });
+
+        if (activity.getCapacity() != null) {
+            long currentCount = activityParticipantRepository.countByActivityIdAndStatusAndParticipantStatusIn(
+                    activity.getId(),
+                    BaseStatus.ACTIVE,
+                    List.of(ParticipantStatus.PENDING, ParticipantStatus.APPROVED, ParticipantStatus.CONFIRMED)
+            );
+            if (currentCount >= activity.getCapacity()) {
+                throw new BusinessException(ActivityErrorCode.ACTIVITY_FULL);
+            }
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        ActivityParticipant participant = ActivityParticipant.builder()
+                .activity(activity)
+                .participant(user)
+                .build();
+
+        activityParticipantRepository.save(participant);
+        log.info("초대 코드로 모임 참여: userId={}, activityId={}", userId, activity.getId());
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -1,8 +1,10 @@
 package com.dewple.activity.service;
 
 import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityInterest;
 import com.dewple.activity.entity.ActivityParticipant;
 import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityInterestRepository;
 import com.dewple.activity.repository.ActivityParticipantRepository;
 import com.dewple.activity.repository.ActivityRepository;
 import com.dewple.activity.repository.CategoryRepository;
@@ -38,6 +40,7 @@ import java.util.List;
 public class ActivityService {
 
     private final ActivityRepository activityRepository;
+    private final ActivityInterestRepository activityInterestRepository;
     private final ActivityParticipantRepository activityParticipantRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
@@ -301,5 +304,61 @@ public class ActivityService {
 
         participant.updateParticipantStatus(status);
         log.info("모임 참여 응답: userId={}, activityId={}, status={}", userId, activityId, status);
+    }
+
+    @Transactional
+    public void addActivityInterest(Long userId, Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        activityInterestRepository.findByActivityIdAndUserId(activityId, userId)
+                .ifPresentOrElse(
+                        interest -> {
+                            if (interest.getStatus() == BaseStatus.ACTIVE) {
+                                throw new BusinessException(ActivityErrorCode.ACTIVITY_INTEREST_ALREADY_EXISTS);
+                            }
+                            interest.activate();
+                        },
+                        () -> {
+                            ActivityInterest interest = ActivityInterest.builder()
+                                    .activity(activity)
+                                    .user(user)
+                                    .build();
+                            activityInterestRepository.save(interest);
+                        }
+                );
+
+        activity.increaseLikeCount();
+        log.info("관심 모임 추가: userId={}, activityId={}", userId, activityId);
+    }
+
+    @Transactional
+    public void removeActivityInterest(Long userId, Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        ActivityInterest interest = activityInterestRepository.findByActivityIdAndUserId(activityId, userId)
+                .filter(i -> i.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_INTEREST_NOT_FOUND));
+
+        interest.inactivate();
+        activity.decreaseLikeCount();
+        log.info("관심 모임 제거: userId={}, activityId={}", userId, activityId);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ActivitySummaryResult> getInterestedActivities(Long userId, Pageable pageable) {
+        return activityRepository.findInterestedActivities(userId, pageable);
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -15,6 +15,7 @@ import com.dewple.common.entity.Category;
 import com.dewple.common.entity.Club;
 import com.dewple.common.entity.Region;
 import com.dewple.common.entity.User;
+import com.dewple.common.enums.ParticipantStatus;
 import com.dewple.common.enums.Permission;
 import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
@@ -236,5 +237,44 @@ public class ActivityService {
         }
 
         return activityParticipantRepository.findParticipantListByActivityId(activityId, pageable);
+    }
+
+    @Transactional
+    public void updateParticipantStatus(Long userId, Long activityId, Long participantId, ParticipantStatus status) {
+        if (status == ParticipantStatus.PENDING) {
+            throw new BusinessException(ActivityErrorCode.INVALID_PARTICIPANT_STATUS);
+        }
+
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        boolean isCreator = activity.getCreator().getId().equals(userId);
+
+        if (activity.getClub() != null) {
+            if (!isCreator) {
+                ClubMember member = clubMemberRepository.findByClubIdAndUserId(activity.getClub().getId(), userId)
+                        .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED));
+
+                if (member.getRole() == null || !member.getRole().hasPermission(Permission.MANAGE_ACTIVITY)) {
+                    throw new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED);
+                }
+            }
+        } else {
+            if (!isCreator) {
+                throw new BusinessException(ActivityErrorCode.ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED);
+            }
+        }
+
+        ActivityParticipant participant = activityParticipantRepository.findById(participantId)
+                .filter(p -> p.getActivity().getId().equals(activityId))
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_FOUND));
+
+        participant.updateParticipantStatus(status);
+        log.info("지원자 상태 변경: participantId={}, activityId={}, status={}", participantId, activityId, status);
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -241,7 +241,7 @@ public class ActivityService {
 
     @Transactional
     public void updateParticipantStatus(Long userId, Long activityId, Long participantId, ParticipantStatus status) {
-        if (status == ParticipantStatus.PENDING) {
+        if (status != ParticipantStatus.APPROVED && status != ParticipantStatus.REJECTED) {
             throw new BusinessException(ActivityErrorCode.INVALID_PARTICIPANT_STATUS);
         }
 
@@ -276,5 +276,30 @@ public class ActivityService {
 
         participant.updateParticipantStatus(status);
         log.info("지원자 상태 변경: participantId={}, activityId={}, status={}", participantId, activityId, status);
+    }
+
+    @Transactional
+    public void respondToParticipation(Long userId, Long activityId, ParticipantStatus status) {
+        if (status != ParticipantStatus.CONFIRMED && status != ParticipantStatus.DECLINED) {
+            throw new BusinessException(ActivityErrorCode.INVALID_PARTICIPATION_RESPONSE);
+        }
+
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        ActivityParticipant participant = activityParticipantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_FOUND));
+
+        if (participant.getParticipantStatus() != ParticipantStatus.APPROVED) {
+            throw new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_APPROVED);
+        }
+
+        participant.updateParticipantStatus(status);
+        log.info("모임 참여 응답: userId={}, activityId={}, status={}", userId, activityId, status);
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ParticipantResult.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ParticipantResult.java
@@ -1,0 +1,15 @@
+package com.dewple.activity.service;
+
+import com.dewple.common.enums.ParticipantStatus;
+
+import java.time.OffsetDateTime;
+
+public record ParticipantResult(
+        Long participantId,
+        Long userId,
+        String profileImg,
+        String name,
+        ParticipantStatus participantStatus,
+        OffsetDateTime appliedAt
+) {
+}

--- a/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
+++ b/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
@@ -1976,4 +1976,295 @@ class ActivityServiceTest {
                 .endAt(END_AT)
                 .build();
     }
+
+    private Activity createActivity(User creator, Club club, OpenType openType) {
+        return Activity.builder()
+                .creator(creator)
+                .club(club)
+                .openType(openType)
+                .name("테스트 모임")
+                .description("테스트 모임입니다")
+                .capacity(20)
+                .isAttendanceCheck(false)
+                .isSearchable(true)
+                .startAt(START_AT)
+                .endAt(END_AT)
+                .inviteCode(openType == OpenType.PRIVATE && club == null ? "test-invite-code" : null)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getInviteCode - 초대 코드 조회")
+    class GetInviteCode {
+
+        @Test
+        @DisplayName("성공: 비공개 개인 모임 초대 코드 조회")
+        void success() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            given(activityRepository.findById(100L)).willReturn(Optional.of(activity));
+
+            // when
+            String inviteCode = activityService.getInviteCode(USER_ID, 100L);
+
+            // then
+            assertThat(inviteCode).isEqualTo("test-invite-code");
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음")
+        void failActivityNotFound() {
+            // given
+            given(activityRepository.findById(100L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getInviteCode(USER_ID, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 모임")
+        void failInactiveActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+            activity.inactivate();
+
+            given(activityRepository.findById(100L)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getInviteCode(USER_ID, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: PUBLIC 모임")
+        void failPublicActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null, OpenType.PUBLIC);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            given(activityRepository.findById(100L)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getInviteCode(USER_ID, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_NOT_PRIVATE);
+        }
+
+        @Test
+        @DisplayName("실패: 동아리 모임")
+        void failClubActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+            Club club = createClub(creator);
+
+            Activity activity = createActivity(creator, club, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            given(activityRepository.findById(100L)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getInviteCode(USER_ID, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_NOT_USER_CREATED);
+        }
+
+        @Test
+        @DisplayName("실패: 생성자가 아닌 유저")
+        void failNotCreator() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 999L);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            given(activityRepository.findById(100L)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getInviteCode(USER_ID, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_INVITE_PERMISSION_DENIED);
+        }
+    }
+
+    @Nested
+    @DisplayName("joinByInviteCode - 초대 코드로 모임 참여")
+    class JoinByInviteCode {
+
+        @Test
+        @DisplayName("성공: 초대 코드로 모임 참여")
+        void success() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 999L);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            User participant = createUser();
+            ReflectionTestUtils.setField(participant, "id", USER_ID);
+
+            given(activityRepository.findByInviteCode("test-invite-code")).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(100L, USER_ID)).willReturn(Optional.empty());
+            given(activityParticipantRepository.countByActivityIdAndStatusAndParticipantStatusIn(
+                    eq(100L), eq(BaseStatus.ACTIVE), any())).willReturn(5L);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(participant));
+            given(activityParticipantRepository.save(any(ActivityParticipant.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            activityService.joinByInviteCode(USER_ID, "test-invite-code");
+
+            // then
+            verify(activityParticipantRepository).save(any(ActivityParticipant.class));
+        }
+
+        @Test
+        @DisplayName("성공: 정원 제한 없는 모임 참여")
+        void successNoCapacityLimit() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 999L);
+
+            Activity activity = Activity.builder()
+                    .creator(creator)
+                    .openType(OpenType.PRIVATE)
+                    .name("테스트 모임")
+                    .description("테스트 모임입니다")
+                    .isAttendanceCheck(false)
+                    .isSearchable(true)
+                    .startAt(START_AT)
+                    .endAt(END_AT)
+                    .inviteCode("test-invite-code")
+                    .build();
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            User participant = createUser();
+            ReflectionTestUtils.setField(participant, "id", USER_ID);
+
+            given(activityRepository.findByInviteCode("test-invite-code")).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(100L, USER_ID)).willReturn(Optional.empty());
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(participant));
+            given(activityParticipantRepository.save(any(ActivityParticipant.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            activityService.joinByInviteCode(USER_ID, "test-invite-code");
+
+            // then
+            verify(activityParticipantRepository).save(any(ActivityParticipant.class));
+            verify(activityParticipantRepository, never()).countByActivityIdAndStatusAndParticipantStatusIn(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 초대 코드")
+        void failInvalidInviteCode() {
+            // given
+            given(activityRepository.findByInviteCode("invalid-code")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.joinByInviteCode(USER_ID, "invalid-code"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.INVITE_CODE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 모임")
+        void failInactiveActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 999L);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+            activity.inactivate();
+
+            given(activityRepository.findByInviteCode("test-invite-code")).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.joinByInviteCode(USER_ID, "test-invite-code"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 본인이 생성한 모임")
+        void failOwnActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            given(activityRepository.findByInviteCode("test-invite-code")).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.joinByInviteCode(USER_ID, "test-invite-code"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.CANNOT_JOIN_OWN_ACTIVITY);
+        }
+
+        @Test
+        @DisplayName("실패: 이미 참가 신청한 모임")
+        void failAlreadyParticipant() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 999L);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            ActivityParticipant existingParticipant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(createUser())
+                    .build();
+
+            given(activityRepository.findByInviteCode("test-invite-code")).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(100L, USER_ID))
+                    .willReturn(Optional.of(existingParticipant));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.joinByInviteCode(USER_ID, "test-invite-code"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ALREADY_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("실패: 정원 초과")
+        void failActivityFull() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 999L);
+
+            Activity activity = createActivity(creator, null, OpenType.PRIVATE);
+            ReflectionTestUtils.setField(activity, "id", 100L);
+
+            given(activityRepository.findByInviteCode("test-invite-code")).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(100L, USER_ID)).willReturn(Optional.empty());
+            given(activityParticipantRepository.countByActivityIdAndStatusAndParticipantStatusIn(
+                    eq(100L), eq(BaseStatus.ACTIVE), any())).willReturn(20L);
+
+            // when & then
+            assertThatThrownBy(() -> activityService.joinByInviteCode(USER_ID, "test-invite-code"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ActivityErrorCode.ACTIVITY_FULL);
+        }
+    }
 }

--- a/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
+++ b/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
@@ -1,8 +1,10 @@
 package com.dewple.activity.service;
 
 import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityInterest;
 import com.dewple.activity.entity.ActivityParticipant;
 import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityInterestRepository;
 import com.dewple.activity.repository.ActivityParticipantRepository;
 import com.dewple.activity.repository.ActivityRepository;
 import com.dewple.activity.repository.CategoryRepository;
@@ -56,6 +58,9 @@ class ActivityServiceTest {
 
     @Mock
     private ActivityRepository activityRepository;
+
+    @Mock
+    private ActivityInterestRepository activityInterestRepository;
 
     @Mock
     private ActivityParticipantRepository activityParticipantRepository;
@@ -1714,6 +1719,227 @@ class ActivityServiceTest {
                         BusinessException be = (BusinessException) e;
                         assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.INVALID_PARTICIPATION_RESPONSE);
                     });
+        }
+    }
+
+    @Nested
+    @DisplayName("addActivityInterest - 관심 모임 추가")
+    class AddActivityInterest {
+
+        private static final Long ACTIVITY_ID = 100L;
+
+        @Test
+        @DisplayName("성공: 관심 모임 추가")
+        void success() {
+            // given
+            User user = createUser();
+            ReflectionTestUtils.setField(user, "id", USER_ID);
+
+            Activity activity = createActivity(user, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(activityInterestRepository.findByActivityIdAndUserId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.empty());
+
+            // when
+            activityService.addActivityInterest(USER_ID, ACTIVITY_ID);
+
+            // then
+            verify(activityInterestRepository).save(any(ActivityInterest.class));
+            assertThat(activity.getLikeCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("성공: 비활성화된 관심 모임 재활성화")
+        void successReactivate() {
+            // given
+            User user = createUser();
+            ReflectionTestUtils.setField(user, "id", USER_ID);
+
+            Activity activity = createActivity(user, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            ActivityInterest interest = ActivityInterest.builder()
+                    .activity(activity)
+                    .user(user)
+                    .build();
+            interest.inactivate();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(activityInterestRepository.findByActivityIdAndUserId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(interest));
+
+            // when
+            activityService.addActivityInterest(USER_ID, ACTIVITY_ID);
+
+            // then
+            assertThat(interest.getStatus()).isEqualTo(BaseStatus.ACTIVE);
+            assertThat(activity.getLikeCount()).isEqualTo(1);
+            verify(activityInterestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음")
+        void failWithActivityNotFound() {
+            // given
+            given(activityRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.addActivityInterest(USER_ID, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 모임")
+        void failWithInactiveActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+            activity.inactivate();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.addActivityInterest(USER_ID, ACTIVITY_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 이미 관심 모임으로 등록")
+        void failWithAlreadyExists() {
+            // given
+            User user = createUser();
+            ReflectionTestUtils.setField(user, "id", USER_ID);
+
+            Activity activity = createActivity(user, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            ActivityInterest interest = ActivityInterest.builder()
+                    .activity(activity)
+                    .user(user)
+                    .build();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(activityInterestRepository.findByActivityIdAndUserId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(interest));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.addActivityInterest(USER_ID, ACTIVITY_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_INTEREST_ALREADY_EXISTS);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("removeActivityInterest - 관심 모임 제거")
+    class RemoveActivityInterest {
+
+        private static final Long ACTIVITY_ID = 100L;
+
+        @Test
+        @DisplayName("성공: 관심 모임 제거")
+        void success() {
+            // given
+            User user = createUser();
+            ReflectionTestUtils.setField(user, "id", USER_ID);
+
+            Activity activity = createActivity(user, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+            ReflectionTestUtils.setField(activity, "likeCount", 1);
+
+            ActivityInterest interest = ActivityInterest.builder()
+                    .activity(activity)
+                    .user(user)
+                    .build();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityInterestRepository.findByActivityIdAndUserId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(interest));
+
+            // when
+            activityService.removeActivityInterest(USER_ID, ACTIVITY_ID);
+
+            // then
+            assertThat(interest.getStatus()).isEqualTo(BaseStatus.INACTIVE);
+            assertThat(activity.getLikeCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음")
+        void failWithActivityNotFound() {
+            // given
+            given(activityRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.removeActivityInterest(USER_ID, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 관심 모임으로 등록되지 않음")
+        void failWithInterestNotFound() {
+            // given
+            User user = createUser();
+            ReflectionTestUtils.setField(user, "id", USER_ID);
+
+            Activity activity = createActivity(user, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityInterestRepository.findByActivityIdAndUserId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.removeActivityInterest(USER_ID, ACTIVITY_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_INTEREST_NOT_FOUND);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("getInterestedActivities - 관심 모임 목록 조회")
+    class GetInterestedActivities {
+
+        @Test
+        @DisplayName("성공: 관심 모임 목록 조회")
+        void success() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Slice<ActivitySummaryResult> emptySlice = new SliceImpl<>(Collections.emptyList(), pageable, false);
+
+            given(activityRepository.findInterestedActivities(USER_ID, pageable)).willReturn(emptySlice);
+
+            // when
+            Slice<ActivitySummaryResult> result = activityService.getInterestedActivities(USER_ID, pageable);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
         }
     }
 

--- a/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
+++ b/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
@@ -20,6 +20,7 @@ import com.dewple.common.enums.ActivityType;
 import com.dewple.common.enums.Gender;
 import com.dewple.common.enums.OpenType;
 import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantStatus;
 import com.dewple.common.enums.Permission;
 import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
@@ -969,6 +970,234 @@ class ActivityServiceTest {
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
                         assertThat(be.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("getParticipantList - 지원자 리스트 조회")
+    class GetParticipantList {
+
+        private static final Long ACTIVITY_ID = 100L;
+        private static final Long OTHER_USER_ID = 2L;
+        private final Pageable pageable = PageRequest.of(0, 10);
+
+        @Test
+        @DisplayName("성공: 개인 모임 생성자가 지원자 리스트 조회")
+        void successWithPersonalActivityCreator() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            List<ParticipantResult> content = List.of(
+                    new ParticipantResult(1L, 2L, "img.jpg", "홍길동", ParticipantStatus.PENDING, OffsetDateTime.now()),
+                    new ParticipantResult(2L, 3L, null, "김철수", ParticipantStatus.APPROVED, OffsetDateTime.now())
+            );
+            Slice<ParticipantResult> slice = new SliceImpl<>(content, pageable, false);
+            given(activityParticipantRepository.findParticipantListByActivityId(ACTIVITY_ID, pageable)).willReturn(slice);
+
+            // when
+            Slice<ParticipantResult> result = activityService.getParticipantList(USER_ID, ACTIVITY_ID, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.getContent().get(0).participantId()).isEqualTo(1L);
+            assertThat(result.getContent().get(0).name()).isEqualTo("홍길동");
+            assertThat(result.getContent().get(0).participantStatus()).isEqualTo(ParticipantStatus.PENDING);
+            assertThat(result.getContent().get(1).participantStatus()).isEqualTo(ParticipantStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("성공: 동아리 모임 생성자가 지원자 리스트 조회")
+        void successWithClubActivityCreator() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Club club = createClub(creator);
+            ReflectionTestUtils.setField(club, "id", CLUB_ID);
+
+            Activity activity = createActivity(creator, club);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            Slice<ParticipantResult> slice = new SliceImpl<>(Collections.emptyList(), pageable, false);
+            given(activityParticipantRepository.findParticipantListByActivityId(ACTIVITY_ID, pageable)).willReturn(slice);
+
+            // when
+            Slice<ParticipantResult> result = activityService.getParticipantList(USER_ID, ACTIVITY_ID, pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 동아리 모임 MANAGE_ACTIVITY 권한자가 조회")
+        void successWithClubActivityManager() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            User manager = createUser();
+            ReflectionTestUtils.setField(manager, "id", OTHER_USER_ID);
+
+            Club club = createClub(creator);
+            ReflectionTestUtils.setField(club, "id", CLUB_ID);
+
+            Activity activity = createActivity(creator, club);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            ClubRole role = ClubRole.builder()
+                    .club(club)
+                    .name("운영진")
+                    .permissions(Permission.MANAGE_ACTIVITY.getValue())
+                    .build();
+
+            ClubMember member = ClubMember.builder()
+                    .club(club)
+                    .user(manager)
+                    .role(role)
+                    .build();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, OTHER_USER_ID)).willReturn(Optional.of(member));
+
+            Slice<ParticipantResult> slice = new SliceImpl<>(Collections.emptyList(), pageable, false);
+            given(activityParticipantRepository.findParticipantListByActivityId(ACTIVITY_ID, pageable)).willReturn(slice);
+
+            // when
+            Slice<ParticipantResult> result = activityService.getParticipantList(OTHER_USER_ID, ACTIVITY_ID, pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공: 빈 결과 반환")
+        void successWithEmptyResult() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            Slice<ParticipantResult> emptySlice = new SliceImpl<>(Collections.emptyList(), pageable, false);
+            given(activityParticipantRepository.findParticipantListByActivityId(ACTIVITY_ID, pageable)).willReturn(emptySlice);
+
+            // when
+            Slice<ParticipantResult> result = activityService.getParticipantList(USER_ID, ACTIVITY_ID, pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음")
+        void failWithActivityNotFound() {
+            // given
+            given(activityRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getParticipantList(USER_ID, 999L, pageable))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 모임")
+        void failWithInactiveActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+            activity.inactivate();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getParticipantList(USER_ID, ACTIVITY_ID, pageable))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 개인 모임에서 생성자가 아닌 유저 조회 시도")
+        void failWithNoPermissionForPersonalActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getParticipantList(OTHER_USER_ID, ACTIVITY_ID, pageable))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 동아리 모임에서 권한 없는 유저 조회 시도")
+        void failWithNoPermissionForClubActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            User otherUser = createUser();
+            ReflectionTestUtils.setField(otherUser, "id", OTHER_USER_ID);
+
+            Club club = createClub(creator);
+            ReflectionTestUtils.setField(club, "id", CLUB_ID);
+
+            Activity activity = createActivity(creator, club);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            ClubRole role = ClubRole.builder()
+                    .club(club)
+                    .name("문의 답변")
+                    .permissions(Permission.ANSWER_INQUIRY.getValue())
+                    .build();
+
+            ClubMember member = ClubMember.builder()
+                    .club(club)
+                    .user(otherUser)
+                    .role(role)
+                    .build();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, OTHER_USER_ID)).willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.getParticipantList(OTHER_USER_ID, ACTIVITY_ID, pageable))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_PARTICIPANT_VIEW_PERMISSION_DENIED);
                     });
         }
     }

--- a/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
+++ b/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
@@ -1515,6 +1515,208 @@ class ActivityServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("respondToParticipation - 모임 참여 응답")
+    class RespondToParticipation {
+
+        private static final Long ACTIVITY_ID = 100L;
+
+        @Test
+        @DisplayName("성공: APPROVED 지원자가 CONFIRMED 선택")
+        void successConfirmed() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 2L);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", USER_ID);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            participant.updateParticipantStatus(ParticipantStatus.APPROVED);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(participant));
+
+            // when
+            activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.CONFIRMED);
+
+            // then
+            assertThat(participant.getParticipantStatus()).isEqualTo(ParticipantStatus.CONFIRMED);
+        }
+
+        @Test
+        @DisplayName("성공: APPROVED 지원자가 DECLINED 선택")
+        void successDeclined() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 2L);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", USER_ID);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            participant.updateParticipantStatus(ParticipantStatus.APPROVED);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(participant));
+
+            // when
+            activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.DECLINED);
+
+            // then
+            assertThat(participant.getParticipantStatus()).isEqualTo(ParticipantStatus.DECLINED);
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음")
+        void failWithActivityNotFound() {
+            // given
+            given(activityRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.respondToParticipation(USER_ID, 999L, ParticipantStatus.CONFIRMED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 모임")
+        void failWithInactiveActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 2L);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+            activity.inactivate();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.CONFIRMED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 지원자가 아닌 유저")
+        void failWithParticipantNotFound() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 2L);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.CONFIRMED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.PARTICIPANT_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: PENDING 상태에서 응답 시도")
+        void failWithPendingStatus() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 2L);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", USER_ID);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(participant));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.CONFIRMED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.PARTICIPANT_NOT_APPROVED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: REJECTED 상태에서 응답 시도")
+        void failWithRejectedStatus() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", 2L);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", USER_ID);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            participant.updateParticipantStatus(ParticipantStatus.REJECTED);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findByActivityIdAndParticipantId(ACTIVITY_ID, USER_ID))
+                    .willReturn(Optional.of(participant));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.CONFIRMED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.PARTICIPANT_NOT_APPROVED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: CONFIRMED/DECLINED 외 상태 입력")
+        void failWithInvalidParticipationResponse() {
+            // when & then
+            assertThatThrownBy(() -> activityService.respondToParticipation(USER_ID, ACTIVITY_ID, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.INVALID_PARTICIPATION_RESPONSE);
+                    });
+        }
+    }
+
     private User createUser() {
         return User.builder()
                 .userId("dewple123")

--- a/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
+++ b/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
@@ -1202,6 +1202,319 @@ class ActivityServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("updateParticipantStatus - 지원자 상태 변경")
+    class UpdateParticipantStatus {
+
+        private static final Long ACTIVITY_ID = 100L;
+        private static final Long PARTICIPANT_ID = 1L;
+        private static final Long OTHER_USER_ID = 2L;
+
+        @Test
+        @DisplayName("성공: 개인 모임 생성자가 지원자 확정")
+        void successApproveByPersonalActivityCreator() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", 3L);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            ReflectionTestUtils.setField(participant, "id", PARTICIPANT_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findById(PARTICIPANT_ID)).willReturn(Optional.of(participant));
+
+            // when
+            activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED);
+
+            // then
+            assertThat(participant.getParticipantStatus()).isEqualTo(ParticipantStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("성공: 개인 모임 생성자가 지원자 거절")
+        void successRejectByPersonalActivityCreator() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", 3L);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            ReflectionTestUtils.setField(participant, "id", PARTICIPANT_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findById(PARTICIPANT_ID)).willReturn(Optional.of(participant));
+
+            // when
+            activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.REJECTED);
+
+            // then
+            assertThat(participant.getParticipantStatus()).isEqualTo(ParticipantStatus.REJECTED);
+        }
+
+        @Test
+        @DisplayName("성공: 동아리 모임 생성자가 지원자 확정")
+        void successApproveByClubActivityCreator() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Club club = createClub(creator);
+            ReflectionTestUtils.setField(club, "id", CLUB_ID);
+
+            Activity activity = createActivity(creator, club);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", 3L);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            ReflectionTestUtils.setField(participant, "id", PARTICIPANT_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findById(PARTICIPANT_ID)).willReturn(Optional.of(participant));
+
+            // when
+            activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED);
+
+            // then
+            assertThat(participant.getParticipantStatus()).isEqualTo(ParticipantStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("성공: 동아리 모임 MANAGE_ACTIVITY 권한자가 지원자 확정")
+        void successApproveByClubActivityManager() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            User manager = createUser();
+            ReflectionTestUtils.setField(manager, "id", OTHER_USER_ID);
+
+            Club club = createClub(creator);
+            ReflectionTestUtils.setField(club, "id", CLUB_ID);
+
+            Activity activity = createActivity(creator, club);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            ClubRole role = ClubRole.builder()
+                    .club(club)
+                    .name("운영진")
+                    .permissions(Permission.MANAGE_ACTIVITY.getValue())
+                    .build();
+
+            ClubMember member = ClubMember.builder()
+                    .club(club)
+                    .user(manager)
+                    .role(role)
+                    .build();
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", 3L);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(activity)
+                    .participant(applicant)
+                    .build();
+            ReflectionTestUtils.setField(participant, "id", PARTICIPANT_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, OTHER_USER_ID)).willReturn(Optional.of(member));
+            given(activityParticipantRepository.findById(PARTICIPANT_ID)).willReturn(Optional.of(participant));
+
+            // when
+            activityService.updateParticipantStatus(OTHER_USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED);
+
+            // then
+            assertThat(participant.getParticipantStatus()).isEqualTo(ParticipantStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("실패: PENDING 상태로 변경 시도")
+        void failWithInvalidStatusPending() {
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.PENDING))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.INVALID_PARTICIPANT_STATUS);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 모임 없음")
+        void failWithActivityNotFound() {
+            // given
+            given(activityRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(USER_ID, 999L, PARTICIPANT_ID, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 모임")
+        void failWithInactiveActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+            activity.inactivate();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 개인 모임에서 생성자가 아닌 유저")
+        void failWithNoPermissionForPersonalActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(OTHER_USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 동아리 모임에서 권한 없는 유저")
+        void failWithNoPermissionForClubActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            User otherUser = createUser();
+            ReflectionTestUtils.setField(otherUser, "id", OTHER_USER_ID);
+
+            Club club = createClub(creator);
+            ReflectionTestUtils.setField(club, "id", CLUB_ID);
+
+            Activity activity = createActivity(creator, club);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            ClubRole role = ClubRole.builder()
+                    .club(club)
+                    .name("문의 답변")
+                    .permissions(Permission.ANSWER_INQUIRY.getValue())
+                    .build();
+
+            ClubMember member = ClubMember.builder()
+                    .club(club)
+                    .user(otherUser)
+                    .role(role)
+                    .build();
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, OTHER_USER_ID)).willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(OTHER_USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_PARTICIPANT_MANAGE_PERMISSION_DENIED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 지원자를 찾을 수 없음")
+        void failWithParticipantNotFound() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, 999L, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.PARTICIPANT_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 다른 모임의 지원자 ID")
+        void failWithParticipantFromDifferentActivity() {
+            // given
+            User creator = createUser();
+            ReflectionTestUtils.setField(creator, "id", USER_ID);
+
+            Activity activity = createActivity(creator, null);
+            ReflectionTestUtils.setField(activity, "id", ACTIVITY_ID);
+
+            Activity otherActivity = createActivity(creator, null);
+            ReflectionTestUtils.setField(otherActivity, "id", 200L);
+
+            User applicant = createUser();
+            ReflectionTestUtils.setField(applicant, "id", 3L);
+
+            ActivityParticipant participant = ActivityParticipant.builder()
+                    .activity(otherActivity)
+                    .participant(applicant)
+                    .build();
+            ReflectionTestUtils.setField(participant, "id", PARTICIPANT_ID);
+
+            given(activityRepository.findById(ACTIVITY_ID)).willReturn(Optional.of(activity));
+            given(activityParticipantRepository.findById(PARTICIPANT_ID)).willReturn(Optional.of(participant));
+
+            // when & then
+            assertThatThrownBy(() -> activityService.updateParticipantStatus(USER_ID, ACTIVITY_ID, PARTICIPANT_ID, ParticipantStatus.APPROVED))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> {
+                        BusinessException be = (BusinessException) e;
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.PARTICIPANT_NOT_FOUND);
+                    });
+        }
+    }
+
     private User createUser() {
         return User.builder()
                 .userId("dewple123")

--- a/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
@@ -3,5 +3,7 @@ package com.dewple.common.enums;
 public enum ParticipantStatus {
     PENDING,
     APPROVED,
-    REJECTED
+    REJECTED,
+    CONFIRMED,
+    DECLINED
 }

--- a/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
@@ -1,0 +1,7 @@
+package com.dewple.common.enums;
+
+public enum ParticipantStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/modules/recruitment/src/test/java/com/dewple/recruitment/service/ApplicationManageServiceTest.java
+++ b/modules/recruitment/src/test/java/com/dewple/recruitment/service/ApplicationManageServiceTest.java
@@ -40,7 +40,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationManageServiceTest {

--- a/modules/recruitment/src/test/java/com/dewple/recruitment/service/RecruitmentServiceTest.java
+++ b/modules/recruitment/src/test/java/com/dewple/recruitment/service/RecruitmentServiceTest.java
@@ -15,7 +15,6 @@ import com.dewple.recruitment.entity.RecruitmentProcess;
 import com.dewple.recruitment.entity.RecruitmentSchema;
 import com.dewple.recruitment.exception.RecruitmentErrorCode;
 import com.dewple.recruitment.repository.RecruitmentPostingRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## 📝 요약

- resolved #22 

## 🔖 변경 사항
- [x] 모임 지원자 리스트 조회 API (운영진)
- [x] 모임 참여 확정/불가능 처리 API (운영진)
- [x] 모임 참여/불참 선택 API (확정된 지원자)
- [x] 관심 모임 추가/제거/조회 API
- [x] 모임 초대 API
- [x] 모임 초대 수락 API

### 비즈니스 흐름                                                                                                                   
                                                            
  - **모임 초대**: 생성자 초대 코드 조회 → 링크 공유 → 수신자가 코드로 참여 신청(`PENDING`)                                            
  - **지원자 관리**: `PENDING` → `APPROVED`/`REJECTED` (운영진 처리)
  - **참여 응답**: `APPROVED` → `CONFIRMED`/`DECLINED` (확정된 지원자 본인 선택)                                                           
  - **관심 모임**: 추가/제거, 관심 모임 목록 조회        

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
