### PR TITLE
[Feat/#33] 회원 및 모임 도메인 수정

### DIFF
--- a/apps/app-api-auth/build.gradle
+++ b/apps/app-api-auth/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	// AWS
 	implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs"
 	implementation "io.awspring.cloud:spring-cloud-aws-starter-ses"
+	implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
 
 	// Swagger
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15"

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -255,4 +255,51 @@ public class ActivityController {
         activityService.joinByInviteCode(userId, request.inviteCode());
         return ApiResponse.ok();
     }
+
+    // ========== 모임관리자 API ==========
+
+    @Operation(summary = "모임관리자 초대 코드 조회", description = "모임장만 조회 가능합니다. 이 코드를 공유하여 모임관리자를 초대합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/{activityId}/manager-invite-code")
+    public ApiResponse<GetInviteCodeResponse> getManagerInviteCode(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        String code = activityService.getManagerInviteCode(userId, activityId);
+        return ApiResponse.ok(new GetInviteCodeResponse(code));
+    }
+
+    @Operation(summary = "모임관리자로 참여", description = "모임관리자 초대 코드를 사용하여 모임관리자로 등록됩니다. 자동 참여 확정되며 최대 모집 인원에 포함되지 않습니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/join-as-manager")
+    public ApiResponse<Void> joinAsManager(
+            @CurrentUserId Long userId,
+            @Valid @RequestBody JoinByInviteCodeRequest request
+    ) {
+        activityService.joinAsManager(userId, request.inviteCode());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "모임관리자 제거", description = "모임장이 특정 모임관리자를 제거합니다. 참여 확정도 함께 취소됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{activityId}/managers/{managerId}")
+    public ApiResponse<Void> removeManager(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long managerId
+    ) {
+        activityService.removeManager(userId, activityId, managerId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "모임관리자 자발적 탈퇴", description = "본인의 모임관리자 자격을 해제합니다. 참여 확정도 함께 취소됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{activityId}/managers/me")
+    public ApiResponse<Void> leaveAsManager(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.leaveAsManager(userId, activityId);
+        return ApiResponse.ok();
+    }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -200,6 +200,40 @@ public class ActivityController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "선착순 참여 신청", description = "선착순 모임에 참여 신청합니다. 정원 이내면 즉시 확정, 초과 시 대기열에 등록됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{activityId}/apply")
+    public ApiResponse<Void> applyFirstCome(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.applyFirstCome(userId, activityId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "대기열 취소", description = "선착순 모임의 대기열 등록을 취소합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{activityId}/waitlist")
+    public ApiResponse<Void> cancelWaitlist(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.cancelWaitlist(userId, activityId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "대기자 선택 참여", description = "본인인증 필수 모임에서 모임장/관리자가 대기자를 선택하여 참여 확정시킵니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{activityId}/waitlist/{participantId}/select")
+    public ApiResponse<Void> selectFromWaitlist(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long participantId
+    ) {
+        activityService.selectFromWaitlist(userId, activityId, participantId);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "참여 취소", description = "참여 확정된 모임의 참여를 취소합니다. 모임 시작 전 + 취소 기한 내에만 가능합니다.")
     @SecurityRequirement(name = BEARER_AUTH)
     @DeleteMapping("/{activityId}/participation")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -17,6 +17,7 @@ import com.dewple.app_api_auth.global.security.CurrentUserId;
 import com.dewple.activity.service.ActivityListSection;
 import com.dewple.activity.service.ActivityService;
 import com.dewple.activity.service.ActivitySummaryResult;
+import com.dewple.activity.service.ActivityHistoryResult;
 import com.dewple.activity.service.CreateActivityParam;
 import com.dewple.activity.service.CreateActivityResult;
 import com.dewple.activity.service.GetActivityDetailResult;
@@ -277,6 +278,17 @@ public class ActivityController {
         Slice<ActivitySummaryResult> results = activityService.getInterestedActivities(userId, pageable);
         Slice<GetActivityListResponse> responseSlice = results.map(GetActivityListResponse::from);
         return ApiResponse.ok(SliceResponse.from(responseSlice));
+    }
+
+    @Operation(summary = "모임 이력 조회", description = "본인이 참여했던 모임 목록을 조회합니다. 취소/강제퇴장 모임은 제외됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/history")
+    public ApiResponse<SliceResponse<ActivityHistoryResult>> getActivityHistory(
+            @CurrentUserId Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Slice<ActivityHistoryResult> results = activityService.getActivityHistory(userId, pageable);
+        return ApiResponse.ok(SliceResponse.from(results));
     }
 
     @Operation(summary = "초대 코드 조회", description = "비공개 개인 모임의 초대 코드를 조회합니다. 모임 생성자만 조회할 수 있습니다.")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -123,6 +123,17 @@ public class ActivityController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "모임 수동 취소", description = "모임장만 모임을 취소할 수 있습니다. 모든 참여자에게 취소 알림이 발송됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{activityId}/cancel")
+    public ApiResponse<Void> cancelActivity(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.cancelActivityManually(userId, activityId);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "모임 상세 조회", description = "모임의 상세 정보를 조회합니다. 모임 기본 정보와 참가자 목록을 반환합니다.")
     @SecurityRequirement(name = BEARER_AUTH)
     @GetMapping("/{activityId}")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityController.java
@@ -74,6 +74,8 @@ public class ActivityController {
                 request.isSearchable(),
                 request.startAt(),
                 request.endAt(),
+                request.emergencyContact(),
+                request.cancelDeadlineDays(),
                 request.categoryId(),
                 request.regionId(),
                 request.activityType(),
@@ -184,6 +186,17 @@ public class ActivityController {
             @Valid @RequestBody RespondToParticipationRequest request
     ) {
         activityService.respondToParticipation(userId, activityId, request.participantStatus());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "참여 취소", description = "참여 확정된 모임의 참여를 취소합니다. 모임 시작 전 + 취소 기한 내에만 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{activityId}/participation")
+    public ApiResponse<Void> cancelParticipation(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        activityService.cancelParticipation(userId, activityId);
         return ApiResponse.ok();
     }
 

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityInquiryController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityInquiryController.java
@@ -1,0 +1,142 @@
+package com.dewple.app_api_auth.api.activity.controller;
+
+import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
+
+import com.dewple.activity.entity.ActivityInquiry;
+import com.dewple.activity.service.ActivityInquiryService;
+import com.dewple.app_api_auth.api.activity.dto.AnswerInquiryRequest;
+import com.dewple.app_api_auth.api.activity.dto.CreateInquiryRequest;
+import com.dewple.app_api_auth.global.response.ApiResponse;
+import com.dewple.app_api_auth.global.response.SliceResponse;
+import com.dewple.app_api_auth.global.security.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Activity Inquiry", description = "모임 문의 API")
+@RestController
+@RequestMapping("/activities/{activityId}/inquiries")
+@RequiredArgsConstructor
+public class ActivityInquiryController {
+
+    private final ActivityInquiryService inquiryService;
+
+    @Operation(summary = "문의 목록 조회", description = "모임의 문의 목록을 조회합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping
+    public ApiResponse<SliceResponse<InquiryResponse>> getInquiryList(
+            @PathVariable Long activityId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Slice<ActivityInquiry> inquiries = inquiryService.getInquiryList(activityId, pageable);
+        Slice<InquiryResponse> response = inquiries.map(InquiryResponse::from);
+        return ApiResponse.ok(SliceResponse.from(response));
+    }
+
+    @Operation(summary = "문의 작성", description = "회원이 모임에 문의를 남깁니다. 익명/실명 선택 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Void> createInquiry(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody CreateInquiryRequest request
+    ) {
+        inquiryService.createInquiry(userId, activityId, request.content(), request.isAnonymous());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "문의 수정 (작성자)", description = "답변이 달리기 전에만 수정 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{inquiryId}")
+    public ApiResponse<Void> updateInquiry(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long inquiryId,
+            @Valid @RequestBody CreateInquiryRequest request
+    ) {
+        inquiryService.updateInquiry(userId, activityId, inquiryId, request.content());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "문의 삭제 (작성자)", description = "답변이 달리기 전에만 삭제 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{inquiryId}")
+    public ApiResponse<Void> deleteInquiryByAuthor(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long inquiryId
+    ) {
+        inquiryService.deleteInquiryByAuthor(userId, activityId, inquiryId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "문의 삭제 (운영진)", description = "모임장/모임관리자가 문의를 삭제합니다. 답변 유무와 무관하게 삭제 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{inquiryId}/admin")
+    public ApiResponse<Void> deleteInquiryByManager(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long inquiryId
+    ) {
+        inquiryService.deleteInquiryByManager(userId, activityId, inquiryId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "문의 답변", description = "모임장/모임관리자가 문의에 답변합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{inquiryId}/answer")
+    public ApiResponse<Void> answerInquiry(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long inquiryId,
+            @Valid @RequestBody AnswerInquiryRequest request
+    ) {
+        inquiryService.answerInquiry(userId, activityId, inquiryId, request.answer());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "문의 답변 수정", description = "모임장/모임관리자가 답변을 수정합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{inquiryId}/answer")
+    public ApiResponse<Void> updateAnswer(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long inquiryId,
+            @Valid @RequestBody AnswerInquiryRequest request
+    ) {
+        inquiryService.updateAnswer(userId, activityId, inquiryId, request.answer());
+        return ApiResponse.ok();
+    }
+
+    // ========== 응답 DTO ==========
+
+    public record InquiryResponse(
+            Long id, String content, Boolean isAnonymous,
+            Long authorId, String authorName,
+            String answer, Long answeredById, String answeredByName
+    ) {
+        public static InquiryResponse from(ActivityInquiry inquiry) {
+            String displayName = inquiry.getIsAnonymous() ? "익명" : inquiry.getAuthor().getName();
+            Long displayAuthorId = inquiry.getIsAnonymous() ? null : inquiry.getAuthor().getId();
+
+            return new InquiryResponse(
+                    inquiry.getId(),
+                    inquiry.getContent(),
+                    inquiry.getIsAnonymous(),
+                    displayAuthorId,
+                    displayName,
+                    inquiry.getAnswer(),
+                    inquiry.getAnsweredBy() != null ? inquiry.getAnsweredBy().getId() : null,
+                    inquiry.getAnsweredBy() != null ? inquiry.getAnsweredBy().getName() : null
+            );
+        }
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityNoticeController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityNoticeController.java
@@ -1,0 +1,166 @@
+package com.dewple.app_api_auth.api.activity.controller;
+
+import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
+
+import com.dewple.activity.entity.ActivityNotice;
+import com.dewple.activity.entity.ActivityNoticeComment;
+import com.dewple.activity.service.ActivityNoticeService;
+import com.dewple.app_api_auth.api.activity.dto.CreateActivityNoticeRequest;
+import com.dewple.app_api_auth.api.activity.dto.CreateCommentRequest;
+import com.dewple.app_api_auth.global.response.ApiResponse;
+import com.dewple.app_api_auth.global.response.SliceResponse;
+import com.dewple.app_api_auth.global.security.CurrentUserId;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Activity Notice", description = "모임 참여자 공지 API")
+@RestController
+@RequestMapping("/activities/{activityId}/notices")
+@RequiredArgsConstructor
+public class ActivityNoticeController {
+
+    private final ActivityNoticeService noticeService;
+    private final ObjectMapper objectMapper;
+
+    @Operation(summary = "공지 목록 조회", description = "참여 확정자만 조회 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping
+    public ApiResponse<SliceResponse<ActivityNoticeResponse>> getNoticeList(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Slice<ActivityNotice> notices = noticeService.getNoticeList(userId, activityId, pageable);
+        Slice<ActivityNoticeResponse> response = notices.map(ActivityNoticeResponse::from);
+        return ApiResponse.ok(SliceResponse.from(response));
+    }
+
+    @Operation(summary = "공지 생성", description = "모임장 또는 모임관리자만 생성 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<ActivityNoticeResponse> createNotice(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody CreateActivityNoticeRequest request
+    ) {
+        String imageUrlsJson = toJson(request.imageUrls());
+        ActivityNotice notice = noticeService.createNotice(
+                userId, activityId, request.title(), request.content(), imageUrlsJson);
+        return ApiResponse.ok(ActivityNoticeResponse.from(notice));
+    }
+
+    @Operation(summary = "공지 수정", description = "모임장 또는 모임관리자만 수정 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{noticeId}")
+    public ApiResponse<Void> updateNotice(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long noticeId,
+            @Valid @RequestBody CreateActivityNoticeRequest request
+    ) {
+        String imageUrlsJson = toJson(request.imageUrls());
+        noticeService.updateNotice(userId, activityId, noticeId,
+                request.title(), request.content(), imageUrlsJson);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "공지 삭제", description = "모임장 또는 모임관리자만 삭제 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{noticeId}")
+    public ApiResponse<Void> deleteNotice(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long noticeId
+    ) {
+        noticeService.deleteNotice(userId, activityId, noticeId);
+        return ApiResponse.ok();
+    }
+
+    // ========== 댓글 ==========
+
+    @Operation(summary = "댓글 목록 조회", description = "참여 확정자만 조회 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/{noticeId}/comments")
+    public ApiResponse<SliceResponse<ActivityNoticeCommentResponse>> getCommentList(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long noticeId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Slice<ActivityNoticeComment> comments = noticeService.getCommentList(
+                userId, activityId, noticeId, pageable);
+        Slice<ActivityNoticeCommentResponse> response = comments.map(ActivityNoticeCommentResponse::from);
+        return ApiResponse.ok(SliceResponse.from(response));
+    }
+
+    @Operation(summary = "댓글 작성", description = "참여 확정자만 작성 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{noticeId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Void> createComment(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long noticeId,
+            @Valid @RequestBody CreateCommentRequest request
+    ) {
+        noticeService.createComment(userId, activityId, noticeId, request.content());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "댓글 삭제", description = "작성자 본인 또는 모임장/모임관리자만 삭제 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{noticeId}/comments/{commentId}")
+    public ApiResponse<Void> deleteComment(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long noticeId,
+            @PathVariable Long commentId
+    ) {
+        noticeService.deleteComment(userId, activityId, noticeId, commentId);
+        return ApiResponse.ok();
+    }
+
+    // ========== 내부 DTO ==========
+
+    public record ActivityNoticeResponse(
+            Long id, String title, String content, String imageUrls,
+            Long authorId, String authorName, int commentCount
+    ) {
+        public static ActivityNoticeResponse from(ActivityNotice notice) {
+            return new ActivityNoticeResponse(
+                    notice.getId(), notice.getTitle(), notice.getContent(),
+                    notice.getImageUrls(), notice.getAuthor().getId(),
+                    notice.getAuthor().getName(), notice.getCommentCount());
+        }
+    }
+
+    public record ActivityNoticeCommentResponse(
+            Long id, String content, Long authorId, String authorName
+    ) {
+        public static ActivityNoticeCommentResponse from(ActivityNoticeComment comment) {
+            return new ActivityNoticeCommentResponse(
+                    comment.getId(), comment.getContent(),
+                    comment.getAuthor().getId(), comment.getAuthor().getName());
+        }
+    }
+
+    private String toJson(Object obj) {
+        if (obj == null) return null;
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityReportController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityReportController.java
@@ -1,0 +1,37 @@
+package com.dewple.app_api_auth.api.activity.controller;
+
+import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
+
+import com.dewple.activity.service.ActivityReportService;
+import com.dewple.app_api_auth.api.activity.dto.CreateReportRequest;
+import com.dewple.app_api_auth.global.response.ApiResponse;
+import com.dewple.app_api_auth.global.security.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Activity Report", description = "모임 신고 API")
+@RestController
+@RequestMapping("/activities/{activityId}/reports")
+@RequiredArgsConstructor
+public class ActivityReportController {
+
+    private final ActivityReportService reportService;
+
+    @Operation(summary = "모임 신고", description = "모임을 신고합니다. 동일 대상에 7일 이내 중복 신고 불가합니다. 모임 정보 스냅샷이 자동 저장됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Void> reportActivity(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody CreateReportRequest request
+    ) {
+        reportService.reportActivity(userId, activityId, request.category(), request.reason());
+        return ApiResponse.ok();
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/StarRatingController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/StarRatingController.java
@@ -1,0 +1,63 @@
+package com.dewple.app_api_auth.api.activity.controller;
+
+import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
+
+import com.dewple.activity.service.StarRatingService;
+import com.dewple.activity.service.StarRatingService.RatingTargetResult;
+import com.dewple.app_api_auth.api.activity.dto.RateParticipantRequest;
+import com.dewple.app_api_auth.global.response.ApiResponse;
+import com.dewple.app_api_auth.global.security.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Star Rating", description = "별점 평가 API")
+@RestController
+@RequestMapping("/activities/{activityId}/ratings")
+@RequiredArgsConstructor
+public class StarRatingController {
+
+    private final StarRatingService starRatingService;
+
+    @Operation(summary = "별점 평가", description = "모임 종료 후 7일 이내, 참여 확정자 간 상호 익명 평가. 자기 자신 불가.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Void> rateParticipant(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody RateParticipantRequest request
+    ) {
+        starRatingService.rateParticipant(userId, activityId, request.rateeId(), request.score());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "평가 대상 목록", description = "해당 모임에서 별점 평가할 수 있는 참여자 목록을 조회합니다. 이미 평가 여부, No-show 여부 포함.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/targets")
+    public ApiResponse<List<RatingTargetResult>> getRatingTargets(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId
+    ) {
+        List<RatingTargetResult> targets = starRatingService.getRatingTargets(userId, activityId);
+        return ApiResponse.ok(targets);
+    }
+
+    @Operation(summary = "No-show 지정", description = "모임장/관리자가 참여자를 No-show로 지정합니다. 출석체크 없는 모임에서 수동 지정 용도.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/no-show/{participantId}")
+    public ApiResponse<Void> markNoShow(
+            @CurrentUserId Long userId,
+            @PathVariable Long activityId,
+            @PathVariable Long participantId
+    ) {
+        starRatingService.markNoShow(userId, activityId, participantId);
+        return ApiResponse.ok();
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/AnswerInquiryRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/AnswerInquiryRequest.java
@@ -1,0 +1,12 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "문의 답변/수정 요청")
+public record AnswerInquiryRequest(
+        @Schema(description = "답변 내용")
+        @NotBlank(message = "답변 내용은 필수입니다.")
+        String answer
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateActivityNoticeRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateActivityNoticeRequest.java
@@ -1,0 +1,23 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "모임 공지 생성/수정 요청")
+public record CreateActivityNoticeRequest(
+        @Schema(description = "공지 제목", example = "4월 모임 장소 안내")
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 200자 이내여야 합니다.")
+        String title,
+
+        @Schema(description = "공지 내용")
+        @NotBlank(message = "내용은 필수입니다.")
+        String content,
+
+        @Schema(description = "이미지 URL 목록")
+        List<String> imageUrls
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateActivityRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateActivityRequest.java
@@ -30,8 +30,7 @@ public record CreateActivityRequest(
         @NotBlank(message = "모임 설명은 필수입니다.")
         String description,
 
-        @Schema(description = "최대 모집 인원 (null이면 제한 없음)", example = "20")
-        @Positive(message = "최대 모집 인원은 1 이상이어야 합니다.")
+        @Schema(description = "최대 모집 인원 (null이면 제한 없음, 0이면 참여 모집 안 함)", example = "20")
         Integer capacity,
 
         @Schema(description = "출석 체크 여부", example = "false")
@@ -48,10 +47,19 @@ public record CreateActivityRequest(
         @NotNull(message = "종료 시간은 필수입니다.")
         OffsetDateTime endAt,
 
+        @Schema(description = "비상연락처 (이메일 또는 전화번호)", example = "010-1234-5678")
+        @NotBlank(message = "비상연락처는 필수입니다.")
+        String emergencyContact,
+
+        @Schema(description = "참여 취소 가능 기한 (모임 시작 n일 전, 0~30, 기본 1)", example = "1")
+        Integer cancelDeadlineDays,
+
         @Schema(description = "카테고리 ID", example = "1")
+        @NotNull(message = "카테고리는 필수입니다.")
         Long categoryId,
 
         @Schema(description = "지역 ID", example = "1")
+        @NotNull(message = "지역은 필수입니다.")
         Long regionId,
 
         @Schema(description = "활동 방식 (ONLINE, OFFLINE, BOTH)", example = "BOTH")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateCommentRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateCommentRequest.java
@@ -1,0 +1,12 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "댓글 작성 요청")
+public record CreateCommentRequest(
+        @Schema(description = "댓글 내용")
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateInquiryRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateInquiryRequest.java
@@ -1,0 +1,15 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "모임 문의 작성 요청")
+public record CreateInquiryRequest(
+        @Schema(description = "문의 내용")
+        @NotBlank(message = "내용은 필수입니다.")
+        String content,
+
+        @Schema(description = "익명 여부", example = "false")
+        Boolean isAnonymous
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateReportRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/CreateReportRequest.java
@@ -1,0 +1,18 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import com.dewple.common.enums.ReportCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "모임 신고 요청")
+public record CreateReportRequest(
+        @Schema(description = "신고 카테고리", example = "INAPPROPRIATE_CONTENT")
+        @NotNull(message = "신고 카테고리는 필수입니다.")
+        ReportCategory category,
+
+        @Schema(description = "신고 사유")
+        @NotBlank(message = "신고 사유는 필수입니다.")
+        String reason
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/RateParticipantRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/dto/RateParticipantRequest.java
@@ -1,0 +1,22 @@
+package com.dewple.app_api_auth.api.activity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+@Schema(description = "별점 평가 요청")
+public record RateParticipantRequest(
+        @Schema(description = "평가 대상 유저 ID")
+        @NotNull(message = "평가 대상은 필수입니다.")
+        Long rateeId,
+
+        @Schema(description = "별점 (0.0~5.0, 0.1 단위)", example = "4.5")
+        @NotNull(message = "별점은 필수입니다.")
+        @DecimalMin(value = "0.0", message = "별점은 0 이상이어야 합니다.")
+        @DecimalMax(value = "5.0", message = "별점은 5 이하여야 합니다.")
+        BigDecimal score
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/PersonalFileController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/PersonalFileController.java
@@ -1,0 +1,100 @@
+package com.dewple.app_api_auth.api.user.controller;
+
+import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
+
+import com.dewple.app_api_auth.api.user.dto.FileDownloadResponse;
+import com.dewple.app_api_auth.api.user.dto.PersonalFileResponse;
+import com.dewple.app_api_auth.api.user.dto.StorageUsageResponse;
+import com.dewple.app_api_auth.global.response.ApiResponse;
+import com.dewple.app_api_auth.global.security.CurrentUserId;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.user.exception.UserErrorCode;
+import com.dewple.user.service.PersonalFileResult;
+import com.dewple.user.service.PersonalFileService;
+import com.dewple.user.service.StorageUsageResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "Personal File", description = "개인 자료실 API")
+@RestController
+@RequestMapping("/users/me/files")
+@RequiredArgsConstructor
+public class PersonalFileController {
+
+    private final PersonalFileService personalFileService;
+
+    @Operation(summary = "파일 업로드", description = "개인 자료실에 파일을 업로드합니다. 1GB 무료 제공.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping
+    public ApiResponse<PersonalFileResponse> uploadFile(
+            @CurrentUserId Long userId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        try {
+            PersonalFileResult result = personalFileService.uploadFile(
+                    userId,
+                    file.getOriginalFilename(),
+                    file.getSize(),
+                    file.getContentType(),
+                    file.getInputStream()
+            );
+            return ApiResponse.ok(PersonalFileResponse.from(result));
+        } catch (IOException e) {
+            throw new BusinessException(UserErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    @Operation(summary = "파일 목록 조회", description = "개인 자료실의 파일 목록을 조회합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping
+    public ApiResponse<List<PersonalFileResponse>> getFiles(
+            @CurrentUserId Long userId
+    ) {
+        List<PersonalFileResponse> files = personalFileService.getFiles(userId).stream()
+                .map(PersonalFileResponse::from)
+                .toList();
+        return ApiResponse.ok(files);
+    }
+
+    @Operation(summary = "파일 다운로드 URL 조회", description = "파일의 다운로드 URL을 생성합니다. URL은 10분간 유효합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/{fileId}/download")
+    public ApiResponse<FileDownloadResponse> getDownloadUrl(
+            @CurrentUserId Long userId,
+            @PathVariable Long fileId
+    ) {
+        String url = personalFileService.getDownloadUrl(userId, fileId);
+        return ApiResponse.ok(new FileDownloadResponse(url));
+    }
+
+    @Operation(summary = "파일 삭제", description = "개인 자료실의 파일을 삭제합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{fileId}")
+    public ApiResponse<Void> deleteFile(
+            @CurrentUserId Long userId,
+            @PathVariable Long fileId
+    ) {
+        personalFileService.deleteFile(userId, fileId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "스토리지 사용량 조회", description = "개인 자료실의 스토리지 사용량을 조회합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/storage")
+    public ApiResponse<StorageUsageResponse> getStorageUsage(
+            @CurrentUserId Long userId
+    ) {
+        StorageUsageResult usage = personalFileService.getStorageUsage(userId);
+        double percent = usage.totalBytes() > 0
+                ? (double) usage.usedBytes() / usage.totalBytes() * 100
+                : 0;
+        return ApiResponse.ok(new StorageUsageResponse(usage.usedBytes(), usage.totalBytes(), Math.round(percent * 10) / 10.0));
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/UserController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/UserController.java
@@ -135,13 +135,23 @@ public class UserController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "회원 탈퇴", description = "본인의 계정을 탈퇴(비활성화) 처리합니다.")
+    @Operation(summary = "회원 탈퇴", description = "본인의 계정을 탈퇴(비활성화) 처리합니다. 7일 이내 취소 가능합니다.")
     @SecurityRequirement(name = BEARER_AUTH)
     @DeleteMapping("/me")
     public ApiResponse<Void> withdraw(
             @CurrentUserId Long userId
     ) {
         userService.withdraw(userId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "회원 탈퇴 취소", description = "소프트삭제 기간(7일) 내에 탈퇴를 취소하고 계정을 복원합니다. 승계된 직위는 복원되지 않습니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/me/cancel-withdrawal")
+    public ApiResponse<Void> cancelWithdrawal(
+            @CurrentUserId Long userId
+    ) {
+        userService.cancelWithdrawal(userId);
         return ApiResponse.ok();
     }
 

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/UserController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.dewple.app_api_auth.api.user.controller;
 import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
 
 import com.dewple.app_api_auth.api.user.dto.ChangePhoneRequest;
+import com.dewple.app_api_auth.api.user.dto.ChangeUserIdRequest;
 import com.dewple.app_api_auth.api.user.dto.CheckUserIdResponse;
 import com.dewple.app_api_auth.api.user.dto.EditMyProfileRequest;
 import com.dewple.app_api_auth.api.user.dto.GetMyProfileResponse;
@@ -54,7 +55,8 @@ public class UserController {
                 user.getWorkplace(),
                 user.getSelfIntroduction(),
                 user.getMbti(),
-                profile.interests()
+                profile.interests(),
+                user.getReputationScore()
         ));
     }
 
@@ -66,10 +68,10 @@ public class UserController {
             @Valid @RequestBody EditMyProfileRequest request
     ) {
         EditMyProfileParam param = new EditMyProfileParam(
-                request.nickname(), request.email(), request.birthdate(),
-                request.gender(), request.university(), request.isGraduated(),
-                request.workplace(), request.profileImg(), request.selfIntroduction(),
-                request.mbti(), request.categoryIds()
+                request.nickname(), request.email(), request.emailVerificationToken(),
+                request.birthdate(), request.gender(), request.university(),
+                request.isGraduated(), request.workplace(), request.profileImg(),
+                request.selfIntroduction(), request.mbti(), request.categoryIds()
         );
 
         MyProfileResult profile = userService.editMyProfile(userId, param);
@@ -88,7 +90,8 @@ public class UserController {
                 user.getWorkplace(),
                 user.getSelfIntroduction(),
                 user.getMbti(),
-                profile.interests()
+                profile.interests(),
+                user.getReputationScore()
         ));
     }
 
@@ -105,8 +108,20 @@ public class UserController {
                 profile.profileImg(),
                 profile.selfIntroduction(),
                 profile.mbti(),
-                profile.interests()
+                profile.interests(),
+                profile.star()
         ));
+    }
+
+    @Operation(summary = "아이디 변경", description = "아이디를 변경합니다. 7일에 한 번만 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/me/user-id")
+    public ApiResponse<Void> changeUserId(
+            @CurrentUserId Long userId,
+            @Valid @RequestBody ChangeUserIdRequest request
+    ) {
+        userService.changeUserId(userId, request.newUserId());
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "내 전화번호 변경", description = "인증된 새 전화번호로 변경합니다.")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/ChangeUserIdRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/ChangeUserIdRequest.java
@@ -1,0 +1,14 @@
+package com.dewple.app_api_auth.api.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "아이디 변경 요청")
+public record ChangeUserIdRequest(
+        @Schema(description = "새 아이디", example = "newdewple123")
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]{3,32}$", message = "아이디는 영문, 숫자 3~32자여야 합니다.")
+        String newUserId
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/EditMyProfileRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/EditMyProfileRequest.java
@@ -20,6 +20,9 @@ public record EditMyProfileRequest(
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         String email,
 
+        @Schema(description = "이메일 인증 토큰 (이메일 변경 시 필수)")
+        String emailVerificationToken,
+
         @Schema(description = "생년월일", example = "2000-01-01")
         LocalDate birthdate,
 

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/FileDownloadResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/FileDownloadResponse.java
@@ -1,0 +1,10 @@
+package com.dewple.app_api_auth.api.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "파일 다운로드 URL 응답")
+public record FileDownloadResponse(
+        @Schema(description = "파일 다운로드 URL (10분간 유효)")
+        String downloadUrl
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/GetMyProfileResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/GetMyProfileResponse.java
@@ -5,6 +5,7 @@ import com.dewple.common.enums.Mbti;
 import com.dewple.common.enums.University;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -47,6 +48,9 @@ public record GetMyProfileResponse(
         Mbti mbti,
 
         @Schema(description = "관심 분야 목록")
-        List<String> interests
+        List<String> interests,
+
+        @Schema(description = "별점 (null이면 평가 없음)", example = "4.2")
+        BigDecimal star
 ) {
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/GetUserProfileResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/GetUserProfileResponse.java
@@ -2,6 +2,7 @@ package com.dewple.app_api_auth.api.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Schema(description = "회원 프로필 조회 응답")
@@ -19,6 +20,9 @@ public record GetUserProfileResponse(
         String mbti,
 
         @Schema(description = "관심 분야 목록")
-        List<String> interests
+        List<String> interests,
+
+        @Schema(description = "별점 (null이면 평가 없음)", example = "4.2")
+        BigDecimal star
 ) {
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/PersonalFileResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/PersonalFileResponse.java
@@ -1,0 +1,27 @@
+package com.dewple.app_api_auth.api.user.dto;
+
+import com.dewple.user.service.PersonalFileResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "개인 자료실 파일 정보")
+public record PersonalFileResponse(
+        @Schema(description = "파일 ID")
+        Long id,
+        @Schema(description = "원본 파일명")
+        String originalName,
+        @Schema(description = "파일 크기 (bytes)")
+        Long fileSize,
+        @Schema(description = "Content-Type")
+        String contentType,
+        @Schema(description = "업로드 시각")
+        OffsetDateTime createdAt
+) {
+    public static PersonalFileResponse from(PersonalFileResult result) {
+        return new PersonalFileResponse(
+                result.id(), result.originalName(), result.fileSize(),
+                result.contentType(), result.createdAt()
+        );
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/StorageUsageResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/dto/StorageUsageResponse.java
@@ -1,0 +1,14 @@
+package com.dewple.app_api_auth.api.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "스토리지 사용량 정보")
+public record StorageUsageResponse(
+        @Schema(description = "사용 중인 용량 (bytes)")
+        long usedBytes,
+        @Schema(description = "총 용량 (bytes)")
+        long totalBytes,
+        @Schema(description = "사용률 (%)")
+        double usagePercent
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
@@ -97,7 +97,9 @@ public class AuthController {
                 request.verificationToken(),
                 request.name(),
                 request.userId(),
-                request.password()
+                request.password(),
+                request.birthdate(),
+                request.gender()
         ));
 
         String accessToken = jwtTokenProvider.generateAccessToken(user.getId());

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
@@ -113,9 +113,9 @@ public class AuthController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "로그인", description = "아이디와 비밀번호로 로그인하고 JWT를 헤더로 발급합니다.")
+    @Operation(summary = "로그인", description = "아이디와 비밀번호로 로그인하고 JWT를 헤더로 발급합니다. 탈퇴 진행 중이면 inDeletionPeriod=true를 반환합니다.")
     @PostMapping("/login")
-    public ApiResponse<Void> login(
+    public ApiResponse<LoginResponse> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse response
     ) {
@@ -130,7 +130,7 @@ public class AuthController {
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("Authorization-Refresh", "Bearer " + refreshToken);
 
-        return ApiResponse.ok();
+        return ApiResponse.ok(new LoginResponse(user.isInDeletionPeriod()));
     }
 
     @Operation(summary = "로그아웃", description = "해당 사용자의 모든 리프레시 토큰을 삭제합니다.")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
@@ -179,4 +179,13 @@ public class AuthController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "비밀번호 찾기", description = "전화번호 인증 후 임시 비밀번호를 SMS로 발송합니다. 카카오 전용 계정은 안내 메시지를 반환합니다.")
+    @PostMapping("/password/reset")
+    public ApiResponse<Void> resetPassword(
+            @Valid @RequestBody ResetPasswordRequest request
+    ) {
+        userService.resetPassword(request.verificationToken());
+        return ApiResponse.ok();
+    }
+
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/controller/AuthController.java
@@ -99,7 +99,8 @@ public class AuthController {
                 request.userId(),
                 request.password(),
                 request.birthdate(),
-                request.gender()
+                request.gender(),
+                request.nickname()
         ));
 
         String accessToken = jwtTokenProvider.generateAccessToken(user.getId());

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/LoginResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.dewple.app_api_auth.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 응답")
+public record LoginResponse(
+        @Schema(description = "탈퇴 진행 중 여부 (true면 탈퇴 취소 안내 필요)")
+        boolean inDeletionPeriod
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/ResetPasswordRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/ResetPasswordRequest.java
@@ -1,0 +1,12 @@
+package com.dewple.app_api_auth.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "비밀번호 찾기 요청")
+public record ResetPasswordRequest(
+        @Schema(description = "전화번호 인증 후 발급받은 본인인증 토큰")
+        @NotBlank(message = "본인인증 토큰은 필수입니다.")
+        String verificationToken
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/SignupRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/SignupRequest.java
@@ -1,9 +1,13 @@
 package com.dewple.app_api_auth.auth.dto;
 
+import com.dewple.common.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
 
 @Schema(description = "회원가입 요청 (1단계)")
 public record SignupRequest(
@@ -18,17 +22,25 @@ public record SignupRequest(
 
         @Schema(description = "아이디", example = "dewple123")
         @NotBlank(message = "아이디는 필수입니다.")
-        @Pattern(regexp = "^[a-zA-Z0-9_]{4,20}$", message = "아이디는 영문, 숫자, 밑줄 4~20자여야 합니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]{3,32}$", message = "아이디는 영문, 숫자 3~32자여야 합니다.")
         String userId,
 
         @Schema(description = "비밀번호", example = "Password1!")
         @NotBlank(message = "비밀번호는 필수입니다.")
-        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=]).{8,20}$",
-                message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~20자여야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=]).{8,32}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~32자여야 합니다.")
         String password,
 
         @Schema(description = "비밀번호 확인", example = "Password1!")
         @NotBlank(message = "비밀번호 확인은 필수입니다.")
-        String passwordConfirm
+        String passwordConfirm,
+
+        @Schema(description = "생년월일", example = "2000-01-01")
+        @NotNull(message = "생년월일은 필수입니다.")
+        LocalDate birthdate,
+
+        @Schema(description = "성별", example = "MALE")
+        @NotNull(message = "성별은 필수입니다.")
+        Gender gender
 ) {
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/SignupRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/auth/dto/SignupRequest.java
@@ -41,6 +41,10 @@ public record SignupRequest(
 
         @Schema(description = "성별", example = "MALE")
         @NotNull(message = "성별은 필수입니다.")
-        Gender gender
+        Gender gender,
+
+        @Schema(description = "닉네임 (선택, 미입력 시 랜덤 생성)", example = "듀플러")
+        @Size(max = 15, message = "닉네임은 15자 이내여야 합니다.")
+        String nickname
 ) {
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/global/config/SecurityConfig.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/global/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                     "/auth/signup",
                     "/auth/login",
                     "/auth/token/refresh",
+                    "/auth/password/reset",
                     // User APIs (인증 불필요)
                     "/users/check-userid",
                     // Recruitment APIs (인증 불필요)

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/sms/SmsVerificationAdapter.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/sms/SmsVerificationAdapter.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class SmsVerificationAdapter implements SmsVerificationPort {
 
     private static final String MESSAGE_TEMPLATE = "[듀플] 인증번호 [%s]를 입력해주세요.";
+    private static final String TEMP_PASSWORD_TEMPLATE = "[듀플] 임시 비밀번호: %s\n로그인 후 반드시 비밀번호를 변경해주세요.";
 
     private final String apiKey;
     private final String apiSecret;
@@ -62,6 +63,27 @@ public class SmsVerificationAdapter implements SmsVerificationPort {
             log.info("SMS 발송 완료: phone={}", maskPhone(phone));
         } catch (Exception e) {
             log.error("SMS 발송 실패: phone={}", maskPhone(phone), e);
+            throw new RuntimeException("SMS 발송 실패", e);
+        }
+    }
+
+    @Override
+    public void sendTemporaryPassword(String phone, String temporaryPassword) {
+        if (messageService == null) {
+            log.warn("SOLAPI 설정이 없어 실제 발송을 건너뜁니다. phone={}, temporaryPassword={}", phone, temporaryPassword);
+            return;
+        }
+
+        Message message = new Message();
+        message.setFrom(senderPhone);
+        message.setTo(phone);
+        message.setText(String.format(TEMP_PASSWORD_TEMPLATE, temporaryPassword));
+
+        try {
+            messageService.sendOne(new SingleMessageSendingRequest(message));
+            log.info("임시 비밀번호 SMS 발송 완료: phone={}", maskPhone(phone));
+        } catch (Exception e) {
+            log.error("임시 비밀번호 SMS 발송 실패: phone={}", maskPhone(phone), e);
             throw new RuntimeException("SMS 발송 실패", e);
         }
     }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/storage/S3FileStorageAdapter.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/storage/S3FileStorageAdapter.java
@@ -1,0 +1,91 @@
+package com.dewple.app_api_auth.infra.storage;
+
+import com.dewple.user.port.FileStoragePort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.io.InputStream;
+import java.time.Duration;
+
+@Slf4j
+@Component
+public class S3FileStorageAdapter implements FileStoragePort {
+
+    private static final Duration PRESIGN_DURATION = Duration.ofMinutes(10);
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final String bucketName;
+
+    public S3FileStorageAdapter(
+            S3Client s3Client,
+            S3Presigner s3Presigner,
+            @Value("${app.storage.bucket:}") String bucketName
+    ) {
+        this.s3Client = s3Client;
+        this.s3Presigner = s3Presigner;
+        this.bucketName = bucketName;
+    }
+
+    @Override
+    public String upload(String key, InputStream inputStream, long contentLength, String contentType) {
+        if (bucketName == null || bucketName.isBlank()) {
+            log.warn("S3 버킷이 설정되지 않아 파일 업로드를 건너뜁니다. key={}", key);
+            return key;
+        }
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromInputStream(inputStream, contentLength));
+        log.info("S3 파일 업로드 완료: key={}", key);
+        return key;
+    }
+
+    @Override
+    public String generateDownloadUrl(String key) {
+        if (bucketName == null || bucketName.isBlank()) {
+            log.warn("S3 버킷이 설정되지 않아 다운로드 URL을 생성할 수 없습니다. key={}", key);
+            return "";
+        }
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(PRESIGN_DURATION)
+                .getObjectRequest(GetObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .build())
+                .build();
+
+        String url = s3Presigner.presignGetObject(presignRequest).url().toString();
+        log.info("S3 Presigned URL 생성: key={}", key);
+        return url;
+    }
+
+    @Override
+    public void delete(String key) {
+        if (bucketName == null || bucketName.isBlank()) {
+            log.warn("S3 버킷이 설정되지 않아 파일 삭제를 건너뜁니다. key={}", key);
+            return;
+        }
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(request);
+        log.info("S3 파일 삭제 완료: key={}", key);
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalActivityAdapter.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalActivityAdapter.java
@@ -33,11 +33,24 @@ public class WithdrawalActivityAdapter implements WithdrawalActivityPort {
             participant.updateParticipantStatus(ParticipantStatus.DECLINED);
             participant.inactivate();
 
-            // TODO: 선착순 모임(hasApplicationForm=false)이면 대기자 자동 승격
-            //       현재 대기열(waitlist) 기능이 미구현 상태이므로 추후 구현 필요
+            // 선착순 모임이면 대기자 자동 승격
+            Activity activity = participant.getActivity();
+            if (!activity.getHasApplicationForm()) {
+                activityParticipantRepository
+                        .findFirstByActivityIdAndStatusAndParticipantStatusAndRoleOrderByWaitlistOrderAsc(
+                                activity.getId(), BaseStatus.ACTIVE,
+                                ParticipantStatus.PENDING, ParticipantRole.PARTICIPANT)
+                        .ifPresent(next -> {
+                            next.updateParticipantStatus(ParticipantStatus.CONFIRMED);
+                            next.clearWaitlistOrder();
+                            // TODO: 승격된 대기자에게 알림 (푸시+알림톡)
+                            log.info("탈퇴로 인한 대기자 자동 승격: userId={}, activityId={}",
+                                    next.getParticipant().getId(), activity.getId());
+                        });
+            }
 
             log.info("탈퇴로 인한 참여 취소: userId={}, activityId={}",
-                    userId, participant.getActivity().getId());
+                    userId, activity.getId());
         }
     }
 

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalActivityAdapter.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalActivityAdapter.java
@@ -1,0 +1,67 @@
+package com.dewple.app_api_auth.infra.withdrawal;
+
+import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.repository.ActivityParticipantRepository;
+import com.dewple.activity.repository.ActivityRepository;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantRole;
+import com.dewple.common.enums.ParticipantStatus;
+import com.dewple.user.port.WithdrawalActivityPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawalActivityAdapter implements WithdrawalActivityPort {
+
+    private final ActivityParticipantRepository activityParticipantRepository;
+    private final ActivityRepository activityRepository;
+
+    @Override
+    public void cancelConfirmedParticipations(Long userId) {
+        List<ActivityParticipant> participations =
+                activityParticipantRepository.findByParticipantIdAndStatusAndParticipantStatusIn(
+                        userId, BaseStatus.ACTIVE,
+                        List.of(ParticipantStatus.CONFIRMED, ParticipantStatus.APPROVED));
+
+        for (ActivityParticipant participant : participations) {
+            participant.updateParticipantStatus(ParticipantStatus.DECLINED);
+            participant.inactivate();
+
+            // TODO: 선착순 모임(hasApplicationForm=false)이면 대기자 자동 승격
+            //       현재 대기열(waitlist) 기능이 미구현 상태이므로 추후 구현 필요
+
+            log.info("탈퇴로 인한 참여 취소: userId={}, activityId={}",
+                    userId, participant.getActivity().getId());
+        }
+    }
+
+    @Override
+    public void transferOrCancelLeaderActivities(Long userId) {
+        List<Activity> leaderActivities =
+                activityRepository.findByCreatorIdAndStatus(userId, BaseStatus.ACTIVE);
+
+        for (Activity activity : leaderActivities) {
+            List<ActivityParticipant> managers =
+                    activityParticipantRepository.findByActivityIdAndStatusAndParticipantStatusAndRole(
+                            activity.getId(), BaseStatus.ACTIVE,
+                            ParticipantStatus.CONFIRMED, ParticipantRole.MANAGER);
+
+            if (!managers.isEmpty()) {
+                ActivityParticipant newLeader = managers.get(0);
+                activity.changeCreator(newLeader.getParticipant());
+                newLeader.updateRole(ParticipantRole.LEADER);
+                log.info("모임장 승계: activityId={}, newLeaderId={}",
+                        activity.getId(), newLeader.getParticipant().getId());
+            } else {
+                activity.inactivate();
+                log.info("모임관리자 부재로 모임 삭제: activityId={}", activity.getId());
+            }
+        }
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalClubAdapter.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalClubAdapter.java
@@ -64,4 +64,17 @@ public class WithdrawalClubAdapter implements WithdrawalClubPort {
                     clubId, successor.getUser().getId());
         }
     }
+
+    @Override
+    public void removeFromAllClubs(Long userId) {
+        List<ClubMember> memberships = clubMemberRepository.findByUserIdAndStatusAndActivityStatus(
+                userId, BaseStatus.ACTIVE, ActivityStatus.ACTIVE);
+
+        for (ClubMember membership : memberships) {
+            membership.updateActivityStatus(ActivityStatus.LEFT);
+            membership.inactivate();
+            log.info("하드삭제로 인한 동아리 탈퇴: userId={}, clubId={}",
+                    userId, membership.getClub().getId());
+        }
+    }
 }

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalClubAdapter.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/infra/withdrawal/WithdrawalClubAdapter.java
@@ -1,0 +1,67 @@
+package com.dewple.app_api_auth.infra.withdrawal;
+
+import com.dewple.club.entity.ClubMember;
+import com.dewple.club.entity.ClubRole;
+import com.dewple.club.repository.ClubMemberRepository;
+import com.dewple.common.enums.ActivityStatus;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.Permission;
+import com.dewple.user.port.WithdrawalClubPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawalClubAdapter implements WithdrawalClubPort {
+
+    private final ClubMemberRepository clubMemberRepository;
+
+    @Override
+    public void transferPresidentRoles(Long userId) {
+        List<ClubMember> memberships = clubMemberRepository.findByUserIdAndStatusAndActivityStatus(
+                userId, BaseStatus.ACTIVE, ActivityStatus.ACTIVE);
+
+        for (ClubMember membership : memberships) {
+            ClubRole role = membership.getRole();
+            if (role == null || !role.hasPermission(Permission.DELEGATE_PRESIDENT)) {
+                continue;
+            }
+
+            Long clubId = membership.getClub().getId();
+
+            List<ClubMember> candidates = clubMemberRepository
+                    .findByClubIdAndStatusAndActivityStatusAndUserIdNot(
+                            clubId, BaseStatus.ACTIVE, ActivityStatus.ACTIVE, userId);
+
+            if (candidates.isEmpty()) {
+                // TODO: 동아리 멤버가 아무도 없으면 동아리 처리 정책 필요 (삭제? 유지?)
+                log.warn("동아리 승계 대상 없음: clubId={}", clubId);
+                membership.changeRole(null);
+                continue;
+            }
+
+            // 승계 우선순위: 운영진(isStaff) > 권한 수 많은 순 > 일반 부원
+            ClubMember successor = candidates.stream()
+                    .sorted(Comparator
+                            .comparing((ClubMember m) -> m.getRole() != null && m.getRole().getIsStaff())
+                            .reversed()
+                            .thenComparing(Comparator
+                                    .comparingLong((ClubMember m) ->
+                                            m.getRole() != null ? Long.bitCount(m.getRole().getPermissions()) : 0)
+                                    .reversed()))
+                    .findFirst()
+                    .orElse(candidates.get(0));
+
+            successor.changeRole(role);
+            membership.changeRole(null);
+
+            log.info("동아리 회장 승계: clubId={}, newPresidentUserId={}",
+                    clubId, successor.getUser().getId());
+        }
+    }
+}

--- a/apps/app-api-auth/src/main/resources/db/migration/V5__add_activity_features_and_personal_file.sql
+++ b/apps/app-api-auth/src/main/resources/db/migration/V5__add_activity_features_and_personal_file.sql
@@ -1,0 +1,100 @@
+-- V5: 개인 자료실 테이블 추가
+-- 2026-03-23
+
+CREATE TABLE IF NOT EXISTS personal_file (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id),
+    original_name   VARCHAR(500) NOT NULL,
+    stored_key      VARCHAR(1000) NOT NULL,
+    file_size       BIGINT NOT NULL,
+    content_type    VARCHAR(100),
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_personal_file_user_id ON personal_file(user_id);
+
+-- 모임관리자 초대 코드
+ALTER TABLE activity ADD COLUMN IF NOT EXISTS manager_invite_code VARCHAR(36) UNIQUE;
+
+-- 모임 생애주기 상태 (RECRUITING/IN_PROGRESS/ENDED/CANCELLED/DELETED)
+ALTER TABLE activity ADD COLUMN IF NOT EXISTS lifecycle_status VARCHAR(20) NOT NULL DEFAULT 'RECRUITING';
+
+-- 모임 참여자 공지
+CREATE TABLE IF NOT EXISTS activity_notice (
+    id              BIGSERIAL PRIMARY KEY,
+    activity_id     BIGINT NOT NULL REFERENCES activity(id),
+    author_id       BIGINT NOT NULL REFERENCES users(id),
+    title           VARCHAR(200) NOT NULL,
+    content         TEXT NOT NULL,
+    image_urls      JSONB,
+    comment_count   INTEGER NOT NULL DEFAULT 0,
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_notice_activity_id ON activity_notice(activity_id);
+
+-- 모임 공지 댓글
+CREATE TABLE IF NOT EXISTS activity_notice_comment (
+    id              BIGSERIAL PRIMARY KEY,
+    notice_id       BIGINT NOT NULL REFERENCES activity_notice(id),
+    author_id       BIGINT NOT NULL REFERENCES users(id),
+    content         TEXT NOT NULL,
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_notice_comment_notice_id ON activity_notice_comment(notice_id);
+
+-- 모임 문의
+CREATE TABLE IF NOT EXISTS activity_inquiry (
+    id              BIGSERIAL PRIMARY KEY,
+    activity_id     BIGINT NOT NULL REFERENCES activity(id),
+    author_id       BIGINT NOT NULL REFERENCES users(id),
+    content         TEXT NOT NULL,
+    is_anonymous    BOOLEAN NOT NULL DEFAULT false,
+    answer          TEXT,
+    answered_by_id  BIGINT REFERENCES users(id),
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_inquiry_activity_id ON activity_inquiry(activity_id);
+
+-- 모임 신고
+CREATE TABLE IF NOT EXISTS activity_report (
+    id              BIGSERIAL PRIMARY KEY,
+    activity_id     BIGINT NOT NULL REFERENCES activity(id),
+    reporter_id     BIGINT NOT NULL REFERENCES users(id),
+    category        VARCHAR(30) NOT NULL,
+    reason          TEXT NOT NULL,
+    report_status   VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    snapshot        JSONB NOT NULL,
+    resolved_at     TIMESTAMPTZ,
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_report_activity_id ON activity_report(activity_id);
+
+-- 별점 평가
+CREATE TABLE IF NOT EXISTS star_rating (
+    id              BIGSERIAL PRIMARY KEY,
+    activity_id     BIGINT NOT NULL REFERENCES activity(id),
+    rater_id        BIGINT NOT NULL REFERENCES users(id),
+    ratee_id        BIGINT NOT NULL REFERENCES users(id),
+    score           DECIMAL(2,1) NOT NULL,
+    is_no_show      BOOLEAN NOT NULL DEFAULT false,
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (activity_id, rater_id, ratee_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_star_rating_ratee_id ON star_rating(ratee_id);

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/activity/controller/ActivityControllerTest.java
@@ -236,7 +236,8 @@ class ActivityControllerTest {
                                     Map.entry("isVerificationRequired", true),
                                     Map.entry("minAge", 20),
                                     Map.entry("maxAge", 30),
-                                    Map.entry("gender", "ANY")
+                                    Map.entry("gender", "ANY"),
+                                    Map.entry("emergencyContact", "010-1234-5678")
                             ))))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.code").value(1000))
@@ -290,7 +291,10 @@ class ActivityControllerTest {
                                     Map.entry("startAt", START_AT),
                                     Map.entry("endAt", END_AT),
                                     Map.entry("activityType", "BOTH"),
-                                    Map.entry("gender", "ANY")
+                                    Map.entry("gender", "ANY"),
+                                    Map.entry("emergencyContact", "010-1234-5678"),
+                                    Map.entry("categoryId", 1),
+                                    Map.entry("regionId", 1)
                             ))))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.code").value(1000))
@@ -453,7 +457,10 @@ class ActivityControllerTest {
                                     "description", "설명",
                                     "activityType", "BOTH",
                                     "startAt", END_AT,
-                                    "endAt", START_AT
+                                    "endAt", START_AT,
+                                    "emergencyContact", "010-1234-5678",
+                                    "categoryId", 1,
+                                    "regionId", 1
                             ))))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(5001));
@@ -477,7 +484,10 @@ class ActivityControllerTest {
                                     "description", "설명",
                                     "activityType", "BOTH",
                                     "startAt", START_AT,
-                                    "endAt", END_AT
+                                    "endAt", END_AT,
+                                    "emergencyContact", "010-1234-5678",
+                                    "categoryId", 1,
+                                    "regionId", 1
                             ))))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value(6002));
@@ -501,7 +511,10 @@ class ActivityControllerTest {
                                     "description", "설명",
                                     "activityType", "BOTH",
                                     "startAt", START_AT,
-                                    "endAt", END_AT
+                                    "endAt", END_AT,
+                                    "emergencyContact", "010-1234-5678",
+                                    "categoryId", 1,
+                                    "regionId", 1
                             ))))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value(6001));
@@ -525,7 +538,10 @@ class ActivityControllerTest {
                                     "description", "설명",
                                     "activityType", "BOTH",
                                     "startAt", START_AT,
-                                    "endAt", END_AT
+                                    "endAt", END_AT,
+                                    "emergencyContact", "010-1234-5678",
+                                    "categoryId", 1,
+                                    "regionId", 1
                             ))))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(6000));

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/user/controller/UserControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/user/controller/UserControllerTest.java
@@ -198,7 +198,8 @@ class UserControllerTest {
                             "https://example.com/img.jpg",
                             "안녕하세요",
                             "INTJ",
-                            List.of("개발", "디자인")
+                            List.of("개발", "디자인"),
+                            null
                     ));
 
             // when & then
@@ -222,7 +223,7 @@ class UserControllerTest {
             // given
             given(userService.getUserProfile(1L))
                     .willReturn(new UserProfileResult(
-                            "홍길동", null, null, null, Collections.emptyList()
+                            "홍길동", null, null, null, Collections.emptyList(), null
                     ));
 
             // when & then
@@ -244,7 +245,7 @@ class UserControllerTest {
             // given
             given(userService.getUserProfile(1L))
                     .willReturn(new UserProfileResult(
-                            "홍길동", null, "자기소개입니다", "ENFP", Collections.emptyList()
+                            "홍길동", null, "자기소개입니다", "ENFP", Collections.emptyList(), null
                     ));
 
             // when & then
@@ -492,21 +493,6 @@ class UserControllerTest {
                     .andExpect(status().isUnauthorized());
         }
 
-        @Test
-        @DisplayName("실패: 이미 사용 중인 닉네임")
-        void failWithNicknameAlreadyExists() throws Exception {
-            // given
-            given(userService.updateProfile(eq(1L), any(UpdateProfileParam.class)))
-                    .willThrow(new BusinessException(UserErrorCode.NICKNAME_ALREADY_EXISTS));
-
-            // when & then
-            mockMvc.perform(patch("/users/me/profile")
-                            .with(jwt().jwt(j -> j.subject("1")))
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"nickname\":\"듀플러\"}"))
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.code").value(4103));
-        }
     }
 
     @Nested
@@ -583,22 +569,6 @@ class UserControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"nickname\":\"새닉네임\"}"))
                     .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        @DisplayName("실패: 닉네임 중복")
-        void failWithNicknameAlreadyExists() throws Exception {
-            // given
-            given(userService.editMyProfile(eq(1L), any(EditMyProfileParam.class)))
-                    .willThrow(new BusinessException(UserErrorCode.NICKNAME_ALREADY_EXISTS));
-
-            // when & then
-            mockMvc.perform(patch("/users/me")
-                            .with(jwt().jwt(j -> j.subject("1")))
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"nickname\":\"중복닉네임\"}"))
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.code").value(4103));
         }
 
         @Test

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/auth/controller/AuthControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/auth/controller/AuthControllerTest.java
@@ -350,7 +350,9 @@ class AuthControllerTest {
                                     "name", "홍길동",
                                     "userId", "dewple123",
                                     "password", "Password1!",
-                                    "passwordConfirm", "Password1!"
+                                    "passwordConfirm", "Password1!",
+                                    "birthdate", "2000-01-01",
+                                    "gender", "MALE"
                             ))))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(1000))
@@ -369,7 +371,9 @@ class AuthControllerTest {
                                     "name", "홍길동",
                                     "userId", "dewple123",
                                     "password", "Password1!",
-                                    "passwordConfirm", "DifferentPassword1!"
+                                    "passwordConfirm", "DifferentPassword1!",
+                                    "birthdate", "2000-01-01",
+                                    "gender", "MALE"
                             ))))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(4106));
@@ -390,7 +394,9 @@ class AuthControllerTest {
                                     "name", "홍길동",
                                     "userId", "dewple123",
                                     "password", "Password1!",
-                                    "passwordConfirm", "Password1!"
+                                    "passwordConfirm", "Password1!",
+                                    "birthdate", "2000-01-01",
+                                    "gender", "MALE"
                             ))))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(4101));
@@ -411,7 +417,9 @@ class AuthControllerTest {
                                     "name", "홍길동",
                                     "userId", "dewple123",
                                     "password", "Password1!",
-                                    "passwordConfirm", "Password1!"
+                                    "passwordConfirm", "Password1!",
+                                    "birthdate", "2000-01-01",
+                                    "gender", "MALE"
                             ))))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(4102));
@@ -427,7 +435,9 @@ class AuthControllerTest {
                                     "name", "홍길동",
                                     "userId", "ab",
                                     "password", "Password1!",
-                                    "passwordConfirm", "Password1!"
+                                    "passwordConfirm", "Password1!",
+                                    "birthdate", "2000-01-01",
+                                    "gender", "MALE"
                             ))))
                     .andExpect(status().isBadRequest());
         }

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/AppWorkerApplication.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/AppWorkerApplication.java
@@ -2,8 +2,10 @@ package com.dewple.app_worker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.dewple")
+@EnableScheduling
 public class AppWorkerApplication {
 
 	public static void main(String[] args) {

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/global/config/JpaConfig.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/global/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.dewple.app_worker.global.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.dewple")
+@EntityScan(basePackages = "com.dewple")
+public class JpaConfig {
+}

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/infra/WithdrawalClubAdapter.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/infra/WithdrawalClubAdapter.java
@@ -1,0 +1,38 @@
+package com.dewple.app_worker.infra;
+
+import com.dewple.club.entity.ClubMember;
+import com.dewple.club.repository.ClubMemberRepository;
+import com.dewple.common.enums.ActivityStatus;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.user.port.WithdrawalClubPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawalClubAdapter implements WithdrawalClubPort {
+
+    private final ClubMemberRepository clubMemberRepository;
+
+    @Override
+    public void transferPresidentRoles(Long userId) {
+        // worker에서는 하드삭제 시점에만 호출되므로 승계는 불필요 (소프트삭제 시점에 이미 처리됨)
+    }
+
+    @Override
+    public void removeFromAllClubs(Long userId) {
+        List<ClubMember> memberships = clubMemberRepository.findByUserIdAndStatusAndActivityStatus(
+                userId, BaseStatus.ACTIVE, ActivityStatus.ACTIVE);
+
+        for (ClubMember membership : memberships) {
+            membership.updateActivityStatus(ActivityStatus.LEFT);
+            membership.inactivate();
+            log.info("하드삭제로 인한 동아리 탈퇴: userId={}, clubId={}",
+                    userId, membership.getClub().getId());
+        }
+    }
+}

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ActivityCancelScheduler.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ActivityCancelScheduler.java
@@ -1,0 +1,29 @@
+package com.dewple.app_worker.job.scheduler;
+
+import com.dewple.activity.service.ActivityService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActivityCancelScheduler {
+
+    private final ActivityService activityService;
+
+    /**
+     * 5분마다 실행.
+     * 모임 시작 시점이 지났는데 일반 참여자(PARTICIPANT)가 한 명도
+     * CONFIRMED가 아닌 모임을 자동 취소한다.
+     * capacity=0 모임은 자동 취소 대상에서 제외.
+     */
+    @Scheduled(fixedDelay = 300_000)
+    public void cancelActivitiesWithNoParticipants() {
+        int cancelled = activityService.cancelActivitiesAutomatically();
+        if (cancelled > 0) {
+            log.info("모임 자동 취소 완료: {}건", cancelled);
+        }
+    }
+}

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ActivityLifecycleScheduler.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ActivityLifecycleScheduler.java
@@ -1,5 +1,6 @@
 package com.dewple.app_worker.job.scheduler;
 
+import com.dewple.activity.service.ActivityReportService;
 import com.dewple.activity.service.ActivityService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class ActivityLifecycleScheduler {
 
     private final ActivityService activityService;
+    private final ActivityReportService activityReportService;
 
     /**
      * 5분마다 실행.
@@ -48,6 +50,18 @@ public class ActivityLifecycleScheduler {
         int deleted = activityService.deleteEndedActivitiesAutomatically();
         if (deleted > 0) {
             log.info("종료 모임 삭제 완료: {}건", deleted);
+        }
+    }
+
+    /**
+     * 매일 1회 실행.
+     * 신고 처리 완료 후 6개월 경과한 스냅샷 자동 삭제.
+     */
+    @Scheduled(fixedDelay = 86_400_000)
+    public void deleteExpiredReportSnapshots() {
+        int deleted = activityReportService.deleteExpiredSnapshots();
+        if (deleted > 0) {
+            log.info("만료 신고 스냅샷 삭제 완료: {}건", deleted);
         }
     }
 }

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ActivityLifecycleScheduler.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ActivityLifecycleScheduler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ActivityCancelScheduler {
+public class ActivityLifecycleScheduler {
 
     private final ActivityService activityService;
 
@@ -24,6 +24,30 @@ public class ActivityCancelScheduler {
         int cancelled = activityService.cancelActivitiesAutomatically();
         if (cancelled > 0) {
             log.info("모임 자동 취소 완료: {}건", cancelled);
+        }
+    }
+
+    /**
+     * 5분마다 실행.
+     * 종료 시점(endAt)이 지난 RECRUITING/IN_PROGRESS 모임을 ENDED로 전환.
+     */
+    @Scheduled(fixedDelay = 300_000)
+    public void endCompletedActivities() {
+        int ended = activityService.endActivitiesAutomatically();
+        if (ended > 0) {
+            log.info("모임 종료 처리 완료: {}건", ended);
+        }
+    }
+
+    /**
+     * 1시간마다 실행.
+     * ENDED 상태에서 7일 경과한 모임을 DELETED로 전환.
+     */
+    @Scheduled(fixedDelay = 3_600_000)
+    public void deleteExpiredActivities() {
+        int deleted = activityService.deleteEndedActivitiesAutomatically();
+        if (deleted > 0) {
+            log.info("종료 모임 삭제 완료: {}건", deleted);
         }
     }
 }

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/UserHardDeleteScheduler.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/UserHardDeleteScheduler.java
@@ -1,6 +1,6 @@
 package com.dewple.app_worker.job.scheduler;
 
-import com.dewple.user.service.UserService;
+import com.dewple.user.service.UserHardDeleteService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserHardDeleteScheduler {
 
-    private final UserService userService;
+    private final UserHardDeleteService userHardDeleteService;
 
     /**
      * 1시간마다 실행.
@@ -19,7 +19,7 @@ public class UserHardDeleteScheduler {
      */
     @Scheduled(fixedDelay = 3_600_000)
     public void hardDeleteExpiredUsers() {
-        int deleted = userService.hardDeleteExpiredUsers();
+        int deleted = userHardDeleteService.hardDeleteExpiredUsers();
         if (deleted > 0) {
             log.info("회원 하드삭제 완료: {}건", deleted);
         }

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/UserHardDeleteScheduler.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/UserHardDeleteScheduler.java
@@ -1,0 +1,27 @@
+package com.dewple.app_worker.job.scheduler;
+
+import com.dewple.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserHardDeleteScheduler {
+
+    private final UserService userService;
+
+    /**
+     * 1시간마다 실행.
+     * deletedAt으로부터 7일 경과한 유저를 하드삭제.
+     */
+    @Scheduled(fixedDelay = 3_600_000)
+    public void hardDeleteExpiredUsers() {
+        int deleted = userService.hardDeleteExpiredUsers();
+        if (deleted > 0) {
+            log.info("회원 하드삭제 완료: {}건", deleted);
+        }
+    }
+}

--- a/apps/app-worker/src/test/java/com/dewple/app_worker/AppWorkerApplicationTests.java
+++ b/apps/app-worker/src/test/java/com/dewple/app_worker/AppWorkerApplicationTests.java
@@ -1,9 +1,11 @@
 package com.dewple.app_worker;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Disabled("Worker context는 외부 인프라(DB, SQS 등) 연결이 필요하므로 CI에서 비활성화")
 class AppWorkerApplicationTests {
 
 	@Test

--- a/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
@@ -110,6 +110,9 @@ public class Activity extends BaseEntity {
     @Column(name = "invite_code", length = 36, unique = true)
     private String inviteCode;
 
+    @Column(name = "manager_invite_code", length = 36, unique = true)
+    private String managerInviteCode;
+
     @Column(name = "emergency_contact", length = 100)
     private String emergencyContact;
 
@@ -137,7 +140,8 @@ public class Activity extends BaseEntity {
                     Category category, Region region, ActivityType activityType,
                     Boolean isVerificationRequired, Integer minAge, Integer maxAge,
                     Gender gender, String thumbnailUrl, String inviteCode,
-                    String emergencyContact, Integer cancelDeadlineDays,
+                    String managerInviteCode, String emergencyContact,
+                    Integer cancelDeadlineDays,
                     OffsetDateTime applicationDeadline, OffsetDateTime resultDate,
                     Boolean hasApplicationForm) {
         this.club = club;
@@ -161,6 +165,7 @@ public class Activity extends BaseEntity {
         this.gender = gender != null ? gender : Gender.ANY;
         this.thumbnailUrl = thumbnailUrl;
         this.inviteCode = inviteCode;
+        this.managerInviteCode = managerInviteCode;
         this.emergencyContact = emergencyContact;
         this.cancelDeadlineDays = cancelDeadlineDays != null ? cancelDeadlineDays : 1;
         this.applicationDeadline = applicationDeadline;

--- a/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
@@ -177,4 +177,8 @@ public class Activity extends BaseEntity {
             this.likeCount--;
         }
     }
+
+    public void changeCreator(User newCreator) {
+        this.creator = newCreator;
+    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/Activity.java
@@ -13,6 +13,7 @@ import com.dewple.common.entity.Category;
 import com.dewple.common.entity.Club;
 import com.dewple.common.entity.Region;
 import com.dewple.common.entity.User;
+import com.dewple.common.enums.ActivityLifecycleStatus;
 import com.dewple.common.enums.ActivityType;
 import com.dewple.common.enums.AttendanceCheckMethod;
 import com.dewple.common.enums.Gender;
@@ -131,6 +132,10 @@ public class Activity extends BaseEntity {
     @Column(name = "has_application_form", nullable = false)
     private Boolean hasApplicationForm = false;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "lifecycle_status", nullable = false, length = 20)
+    private ActivityLifecycleStatus lifecycleStatus = ActivityLifecycleStatus.RECRUITING;
+
     @Builder
     public Activity(Club club, Organization organization, User creator, OpenType openType,
                     String name, String description, Integer capacity,
@@ -171,6 +176,25 @@ public class Activity extends BaseEntity {
         this.applicationDeadline = applicationDeadline;
         this.resultDate = resultDate;
         this.hasApplicationForm = hasApplicationForm != null ? hasApplicationForm : false;
+        this.lifecycleStatus = ActivityLifecycleStatus.RECRUITING;
+    }
+
+    public void cancel() {
+        this.lifecycleStatus = ActivityLifecycleStatus.CANCELLED;
+        this.inactivate();
+    }
+
+    public void markEnded() {
+        this.lifecycleStatus = ActivityLifecycleStatus.ENDED;
+    }
+
+    public void markDeleted() {
+        this.lifecycleStatus = ActivityLifecycleStatus.DELETED;
+        this.inactivate();
+    }
+
+    public void startProgress() {
+        this.lifecycleStatus = ActivityLifecycleStatus.IN_PROGRESS;
     }
 
     public void increaseLikeCount() {

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityInquiry.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityInquiry.java
@@ -1,0 +1,66 @@
+package com.dewple.activity.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "activity_inquiry")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityInquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "is_anonymous", nullable = false)
+    private Boolean isAnonymous = false;
+
+    @Column(name = "answer", columnDefinition = "TEXT")
+    private String answer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answered_by_id")
+    private User answeredBy;
+
+    @Builder
+    public ActivityInquiry(Activity activity, User author, String content, Boolean isAnonymous) {
+        this.activity = activity;
+        this.author = author;
+        this.content = content;
+        this.isAnonymous = isAnonymous != null ? isAnonymous : false;
+    }
+
+    public boolean hasAnswer() {
+        return this.answer != null;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void setAnswer(String answer, User answeredBy) {
+        this.answer = answer;
+        this.answeredBy = answeredBy;
+    }
+
+    public void updateAnswer(String answer) {
+        this.answer = answer;
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityNotice.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityNotice.java
@@ -1,0 +1,66 @@
+package com.dewple.activity.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "activity_notice")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityNotice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "image_urls", columnDefinition = "jsonb")
+    private String imageUrls;
+
+    @Column(name = "comment_count", nullable = false)
+    private int commentCount = 0;
+
+    @Builder
+    public ActivityNotice(Activity activity, User author, String title, String content, String imageUrls) {
+        this.activity = activity;
+        this.author = author;
+        this.title = title;
+        this.content = content;
+        this.imageUrls = imageUrls;
+    }
+
+    public void update(String title, String content, String imageUrls) {
+        if (title != null) this.title = title;
+        if (content != null) this.content = content;
+        if (imageUrls != null) this.imageUrls = imageUrls;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        if (this.commentCount > 0) this.commentCount--;
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityNoticeComment.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityNoticeComment.java
@@ -1,0 +1,38 @@
+package com.dewple.activity.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "activity_notice_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityNoticeComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private ActivityNotice notice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    public ActivityNoticeComment(ActivityNotice notice, User author, String content) {
+        this.notice = notice;
+        this.author = author;
+        this.content = content;
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
@@ -59,4 +59,8 @@ public class ActivityParticipant extends BaseEntity {
     public void updateParticipantStatus(ParticipantStatus participantStatus) {
         this.participantStatus = participantStatus;
     }
+
+    public void updateRole(ParticipantRole role) {
+        this.role = role;
+    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityParticipant.java
@@ -63,4 +63,8 @@ public class ActivityParticipant extends BaseEntity {
     public void updateRole(ParticipantRole role) {
         this.role = role;
     }
+
+    public void clearWaitlistOrder() {
+        this.waitlistOrder = null;
+    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/entity/ActivityReport.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/ActivityReport.java
@@ -1,0 +1,72 @@
+package com.dewple.activity.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.ReportCategory;
+import com.dewple.common.enums.ReportStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "activity_report")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 30)
+    private ReportCategory category;
+
+    @Column(name = "reason", nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_status", nullable = false, length = 20)
+    private ReportStatus reportStatus = ReportStatus.PENDING;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "snapshot", nullable = false, columnDefinition = "jsonb")
+    private String snapshot;
+
+    @Column(name = "resolved_at", columnDefinition = "timestamptz")
+    private OffsetDateTime resolvedAt;
+
+    @Builder
+    public ActivityReport(Activity activity, User reporter, ReportCategory category,
+                          String reason, String snapshot) {
+        this.activity = activity;
+        this.reporter = reporter;
+        this.category = category;
+        this.reason = reason;
+        this.snapshot = snapshot;
+    }
+
+    public void resolve() {
+        this.reportStatus = ReportStatus.RESOLVED;
+        this.resolvedAt = OffsetDateTime.now();
+    }
+
+    public void dismiss() {
+        this.reportStatus = ReportStatus.DISMISSED;
+        this.resolvedAt = OffsetDateTime.now();
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/entity/StarRating.java
+++ b/modules/activity/src/main/java/com/dewple/activity/entity/StarRating.java
@@ -1,0 +1,51 @@
+package com.dewple.activity.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "star_rating", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"activity_id", "rater_id", "ratee_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StarRating extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rater_id", nullable = false)
+    private User rater;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ratee_id", nullable = false)
+    private User ratee;
+
+    @Column(name = "score", nullable = false, precision = 2, scale = 1)
+    private BigDecimal score;
+
+    @Column(name = "is_no_show", nullable = false)
+    private Boolean isNoShow = false;
+
+    @Builder
+    public StarRating(Activity activity, User rater, User ratee, BigDecimal score, Boolean isNoShow) {
+        this.activity = activity;
+        this.rater = rater;
+        this.ratee = ratee;
+        this.score = score;
+        this.isNoShow = isNoShow != null ? isNoShow : false;
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -37,6 +37,11 @@ public enum ActivityErrorCode implements ErrorCode {
     CANCEL_DEADLINE_EXCEEDED(5024, HttpStatus.BAD_REQUEST, "참여 취소 가능 기한이 지났습니다."),
     ACTIVITY_ALREADY_STARTED(5025, HttpStatus.BAD_REQUEST, "이미 시작된 모임은 참여를 취소할 수 없습니다."),
     PARTICIPANT_NOT_CONFIRMED(5026, HttpStatus.BAD_REQUEST, "참여 확정 상태가 아닙니다."),
+    MANAGER_LIMIT_EXCEEDED(5027, HttpStatus.BAD_REQUEST, "모임관리자는 최대 50명까지 초대 가능합니다."),
+    NOT_ACTIVITY_LEADER(5028, HttpStatus.FORBIDDEN, "모임장만 수행할 수 있습니다."),
+    ALREADY_MANAGER(5029, HttpStatus.CONFLICT, "이미 모임관리자로 등록되어 있습니다."),
+    MANAGER_NOT_FOUND(5030, HttpStatus.NOT_FOUND, "해당 모임관리자를 찾을 수 없습니다."),
+    CANNOT_REMOVE_LEADER(5031, HttpStatus.BAD_REQUEST, "모임장은 제거할 수 없습니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -50,6 +50,11 @@ public enum ActivityErrorCode implements ErrorCode {
     NOT_FIRST_COME_ACTIVITY(5037, HttpStatus.BAD_REQUEST, "선착순 모임이 아닙니다."),
     NOT_IN_WAITLIST(5038, HttpStatus.BAD_REQUEST, "대기열에 등록되어 있지 않습니다."),
     VERIFICATION_REQUIRED_FOR_SELECT(5039, HttpStatus.BAD_REQUEST, "본인인증 필수 모임에서만 대기자 선택 참여가 가능합니다."),
+    CANNOT_RATE_SELF(5040, HttpStatus.BAD_REQUEST, "자기 자신에게는 별점을 줄 수 없습니다."),
+    ALREADY_RATED(5041, HttpStatus.CONFLICT, "이미 별점을 부여한 참여자입니다."),
+    INVALID_RATING_SCORE(5042, HttpStatus.BAD_REQUEST, "별점은 0~5 범위여야 합니다."),
+    RATING_NOT_AVAILABLE(5043, HttpStatus.BAD_REQUEST, "별점 평가가 가능한 상태가 아닙니다."),
+    RATING_PERIOD_EXPIRED(5044, HttpStatus.BAD_REQUEST, "별점 평가 기간(7일)이 만료되었습니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -46,6 +46,7 @@ public enum ActivityErrorCode implements ErrorCode {
     INQUIRY_NOT_FOUND(5033, HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
     INQUIRY_ALREADY_ANSWERED(5034, HttpStatus.BAD_REQUEST, "답변이 달린 문의는 수정/삭제할 수 없습니다."),
     INQUIRY_NOT_ANSWERED(5035, HttpStatus.BAD_REQUEST, "아직 답변이 없는 문의입니다."),
+    REPORT_COOLDOWN(5036, HttpStatus.TOO_MANY_REQUESTS, "동일 대상에 대한 신고는 7일 후 가능합니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -42,6 +42,7 @@ public enum ActivityErrorCode implements ErrorCode {
     ALREADY_MANAGER(5029, HttpStatus.CONFLICT, "이미 모임관리자로 등록되어 있습니다."),
     MANAGER_NOT_FOUND(5030, HttpStatus.NOT_FOUND, "해당 모임관리자를 찾을 수 없습니다."),
     CANNOT_REMOVE_LEADER(5031, HttpStatus.BAD_REQUEST, "모임장은 제거할 수 없습니다."),
+    ACTIVITY_ALREADY_CANCELLED(5032, HttpStatus.BAD_REQUEST, "이미 취소된 모임입니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -43,6 +43,9 @@ public enum ActivityErrorCode implements ErrorCode {
     MANAGER_NOT_FOUND(5030, HttpStatus.NOT_FOUND, "해당 모임관리자를 찾을 수 없습니다."),
     CANNOT_REMOVE_LEADER(5031, HttpStatus.BAD_REQUEST, "모임장은 제거할 수 없습니다."),
     ACTIVITY_ALREADY_CANCELLED(5032, HttpStatus.BAD_REQUEST, "이미 취소된 모임입니다."),
+    INQUIRY_NOT_FOUND(5033, HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+    INQUIRY_ALREADY_ANSWERED(5034, HttpStatus.BAD_REQUEST, "답변이 달린 문의는 수정/삭제할 수 없습니다."),
+    INQUIRY_NOT_ANSWERED(5035, HttpStatus.BAD_REQUEST, "아직 답변이 없는 문의입니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -32,6 +32,7 @@ public enum ActivityErrorCode implements ErrorCode {
     ACTIVITY_FULL(5019, HttpStatus.CONFLICT, "모임 정원이 가득 찼습니다."),
     CANNOT_JOIN_OWN_ACTIVITY(5020, HttpStatus.BAD_REQUEST, "본인이 생성한 모임에는 참가할 수 없습니다."),
     ACTIVITY_NOT_USER_CREATED(5021, HttpStatus.BAD_REQUEST, "개인 모임만 초대 코드를 사용할 수 있습니다."),
+    INTEREST_LIMIT_EXCEEDED(5022, HttpStatus.BAD_REQUEST, "관심 모임은 최대 20개까지 설정 가능합니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -47,6 +47,9 @@ public enum ActivityErrorCode implements ErrorCode {
     INQUIRY_ALREADY_ANSWERED(5034, HttpStatus.BAD_REQUEST, "답변이 달린 문의는 수정/삭제할 수 없습니다."),
     INQUIRY_NOT_ANSWERED(5035, HttpStatus.BAD_REQUEST, "아직 답변이 없는 문의입니다."),
     REPORT_COOLDOWN(5036, HttpStatus.TOO_MANY_REQUESTS, "동일 대상에 대한 신고는 7일 후 가능합니다."),
+    NOT_FIRST_COME_ACTIVITY(5037, HttpStatus.BAD_REQUEST, "선착순 모임이 아닙니다."),
+    NOT_IN_WAITLIST(5038, HttpStatus.BAD_REQUEST, "대기열에 등록되어 있지 않습니다."),
+    VERIFICATION_REQUIRED_FOR_SELECT(5039, HttpStatus.BAD_REQUEST, "본인인증 필수 모임에서만 대기자 선택 참여가 가능합니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
+++ b/modules/activity/src/main/java/com/dewple/activity/exception/ActivityErrorCode.java
@@ -33,6 +33,10 @@ public enum ActivityErrorCode implements ErrorCode {
     CANNOT_JOIN_OWN_ACTIVITY(5020, HttpStatus.BAD_REQUEST, "본인이 생성한 모임에는 참가할 수 없습니다."),
     ACTIVITY_NOT_USER_CREATED(5021, HttpStatus.BAD_REQUEST, "개인 모임만 초대 코드를 사용할 수 있습니다."),
     INTEREST_LIMIT_EXCEEDED(5022, HttpStatus.BAD_REQUEST, "관심 모임은 최대 20개까지 설정 가능합니다."),
+    LEADER_ACTIVITY_LIMIT_EXCEEDED(5023, HttpStatus.BAD_REQUEST, "모임장으로서 동시 운영 가능한 모임은 최대 10개입니다."),
+    CANCEL_DEADLINE_EXCEEDED(5024, HttpStatus.BAD_REQUEST, "참여 취소 가능 기한이 지났습니다."),
+    ACTIVITY_ALREADY_STARTED(5025, HttpStatus.BAD_REQUEST, "이미 시작된 모임은 참여를 취소할 수 없습니다."),
+    PARTICIPANT_NOT_CONFIRMED(5026, HttpStatus.BAD_REQUEST, "참여 확정 상태가 아닙니다."),
     ;
 
     private final int code;

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityInquiryRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityInquiryRepository.java
@@ -1,0 +1,15 @@
+package com.dewple.activity.repository;
+
+import com.dewple.activity.entity.ActivityInquiry;
+import com.dewple.common.enums.BaseStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityInquiryRepository extends JpaRepository<ActivityInquiry, Long> {
+
+    Slice<ActivityInquiry> findByActivityIdAndStatusOrderByCreatedAtDesc(
+            Long activityId, BaseStatus status, Pageable pageable);
+
+    long countByActivityIdAndStatus(Long activityId, BaseStatus status);
+}

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityInterestRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityInterestRepository.java
@@ -1,6 +1,7 @@
 package com.dewple.activity.repository;
 
 import com.dewple.activity.entity.ActivityInterest;
+import com.dewple.common.enums.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.Optional;
 public interface ActivityInterestRepository extends JpaRepository<ActivityInterest, Long> {
 
     Optional<ActivityInterest> findByActivityIdAndUserId(Long activityId, Long userId);
+
+    long countByUserIdAndStatus(Long userId, BaseStatus status);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityNoticeCommentRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityNoticeCommentRepository.java
@@ -1,0 +1,13 @@
+package com.dewple.activity.repository;
+
+import com.dewple.activity.entity.ActivityNoticeComment;
+import com.dewple.common.enums.BaseStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityNoticeCommentRepository extends JpaRepository<ActivityNoticeComment, Long> {
+
+    Slice<ActivityNoticeComment> findByNoticeIdAndStatusOrderByCreatedAtAsc(
+            Long noticeId, BaseStatus status, Pageable pageable);
+}

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityNoticeRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityNoticeRepository.java
@@ -1,0 +1,13 @@
+package com.dewple.activity.repository;
+
+import com.dewple.activity.entity.ActivityNotice;
+import com.dewple.common.enums.BaseStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityNoticeRepository extends JpaRepository<ActivityNotice, Long> {
+
+    Slice<ActivityNotice> findByActivityIdAndStatusOrderByCreatedAtDesc(
+            Long activityId, BaseStatus status, Pageable pageable);
+}

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
@@ -4,6 +4,7 @@ import com.dewple.activity.entity.ActivityParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantRole;
 import com.dewple.common.enums.ParticipantStatus;
 
 import java.util.List;
@@ -16,4 +17,10 @@ public interface ActivityParticipantRepository extends JpaRepository<ActivityPar
     Optional<ActivityParticipant> findByActivityIdAndParticipantId(Long activityId, Long participantId);
 
     long countByActivityIdAndStatusAndParticipantStatusIn(Long activityId, BaseStatus status, List<ParticipantStatus> participantStatuses);
+
+    List<ActivityParticipant> findByParticipantIdAndStatusAndParticipantStatusIn(
+            Long participantId, BaseStatus status, List<ParticipantStatus> statuses);
+
+    List<ActivityParticipant> findByActivityIdAndStatusAndParticipantStatusAndRole(
+            Long activityId, BaseStatus status, ParticipantStatus participantStatus, ParticipantRole role);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
@@ -26,6 +26,9 @@ public interface ActivityParticipantRepository extends JpaRepository<ActivityPar
 
     long countByActivityIdAndStatusAndRole(Long activityId, BaseStatus status, ParticipantRole role);
 
+    long countByActivityIdAndStatusAndParticipantStatusAndRole(
+            Long activityId, BaseStatus status, ParticipantStatus participantStatus, ParticipantRole role);
+
     Optional<ActivityParticipant> findByActivityIdAndParticipantIdAndStatusAndRole(
             Long activityId, Long participantId, BaseStatus status, ParticipantRole role);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
@@ -31,4 +31,16 @@ public interface ActivityParticipantRepository extends JpaRepository<ActivityPar
 
     Optional<ActivityParticipant> findByActivityIdAndParticipantIdAndStatusAndRole(
             Long activityId, Long participantId, BaseStatus status, ParticipantRole role);
+
+    long countByActivityIdAndStatusAndParticipantStatusInAndRole(
+            Long activityId, BaseStatus status, List<ParticipantStatus> statuses, ParticipantRole role);
+
+    Optional<ActivityParticipant> findFirstByActivityIdAndStatusAndParticipantStatusAndRoleOrderByWaitlistOrderAsc(
+            Long activityId, BaseStatus status, ParticipantStatus participantStatus, ParticipantRole role);
+
+    Optional<ActivityParticipant> findFirstByActivityIdAndStatusAndRoleOrderByWaitlistOrderDesc(
+            Long activityId, BaseStatus status, ParticipantRole role);
+
+    List<ActivityParticipant> findByActivityIdAndStatusAndParticipantStatusAndRoleOrderByWaitlistOrderAsc(
+            Long activityId, BaseStatus status, ParticipantStatus participantStatus, ParticipantRole role);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepository.java
@@ -23,4 +23,9 @@ public interface ActivityParticipantRepository extends JpaRepository<ActivityPar
 
     List<ActivityParticipant> findByActivityIdAndStatusAndParticipantStatusAndRole(
             Long activityId, BaseStatus status, ParticipantStatus participantStatus, ParticipantRole role);
+
+    long countByActivityIdAndStatusAndRole(Long activityId, BaseStatus status, ParticipantRole role);
+
+    Optional<ActivityParticipant> findByActivityIdAndParticipantIdAndStatusAndRole(
+            Long activityId, Long participantId, BaseStatus status, ParticipantRole role);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryCustom.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.dewple.activity.repository;
 
 import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.service.ActivityHistoryResult;
 import com.dewple.activity.service.ParticipantResult;
 import com.dewple.common.enums.BaseStatus;
 import org.springframework.data.domain.Pageable;
@@ -13,4 +14,6 @@ public interface ActivityParticipantRepositoryCustom {
     List<ActivityParticipant> findByActivityIdAndStatusWithParticipant(Long activityId, BaseStatus status);
 
     Slice<ParticipantResult> findParticipantListByActivityId(Long activityId, Pageable pageable);
+
+    Slice<ActivityHistoryResult> findActivityHistoryByUserId(Long userId, Pageable pageable);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryImpl.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityParticipantRepositoryImpl.java
@@ -1,10 +1,15 @@
 package com.dewple.activity.repository;
 
 import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.entity.QActivity;
 import com.dewple.activity.entity.QActivityParticipant;
+import com.dewple.activity.service.ActivityHistoryResult;
 import com.dewple.activity.service.ParticipantResult;
+import com.dewple.common.enums.ActivityLifecycleStatus;
 import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantStatus;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -50,6 +55,48 @@ public class ActivityParticipantRepositoryImpl implements ActivityParticipantRep
                         activityParticipant.status.eq(BaseStatus.ACTIVE)
                 )
                 .orderBy(activityParticipant.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content = content.subList(0, pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<ActivityHistoryResult> findActivityHistoryByUserId(Long userId, Pageable pageable) {
+        QActivity activity = QActivity.activity;
+
+        List<ActivityHistoryResult> content = queryFactory
+                .select(Projections.constructor(ActivityHistoryResult.class,
+                        activity.id,
+                        activity.name,
+                        activity.thumbnailUrl,
+                        Expressions.cases()
+                                .when(activity.club.isNull().and(activity.organization.isNull()))
+                                .then("PERSONAL")
+                                .when(activity.club.isNotNull())
+                                .then("CLUB")
+                                .otherwise("ORGANIZATION"),
+                        activity.club.name,
+                        activity.startAt,
+                        activity.endAt
+                ))
+                .from(activityParticipant)
+                .join(activityParticipant.activity, activity)
+                .leftJoin(activity.club)
+                .where(
+                        activityParticipant.participant.id.eq(userId),
+                        activityParticipant.status.eq(BaseStatus.ACTIVE),
+                        activityParticipant.participantStatus.eq(ParticipantStatus.CONFIRMED),
+                        // 취소된 모임 제외
+                        activity.lifecycleStatus.ne(ActivityLifecycleStatus.CANCELLED)
+                )
+                .orderBy(activity.endAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityReportRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityReportRepository.java
@@ -1,0 +1,18 @@
+package com.dewple.activity.repository;
+
+import com.dewple.activity.entity.ActivityReport;
+import com.dewple.common.enums.ReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ActivityReportRepository extends JpaRepository<ActivityReport, Long> {
+
+    Optional<ActivityReport> findTopByActivityIdAndReporterIdOrderByCreatedAtDesc(
+            Long activityId, Long reporterId);
+
+    List<ActivityReport> findByReportStatusAndResolvedAtBefore(
+            ReportStatus status, OffsetDateTime before);
+}

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
@@ -3,8 +3,10 @@ package com.dewple.activity.repository;
 import com.dewple.activity.entity.Activity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.dewple.common.enums.ActivityLifecycleStatus;
 import com.dewple.common.enums.BaseStatus;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +17,6 @@ public interface ActivityRepository extends JpaRepository<Activity, Long>, Activ
     Optional<Activity> findByManagerInviteCode(String managerInviteCode);
 
     List<Activity> findByCreatorIdAndStatus(Long creatorId, BaseStatus status);
+
+    List<Activity> findByLifecycleStatusAndStartAtBefore(ActivityLifecycleStatus lifecycleStatus, OffsetDateTime startAt);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
@@ -3,9 +3,14 @@ package com.dewple.activity.repository;
 import com.dewple.activity.entity.Activity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.dewple.common.enums.BaseStatus;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface ActivityRepository extends JpaRepository<Activity, Long>, ActivityRepositoryCustom {
 
     Optional<Activity> findByInviteCode(String inviteCode);
+
+    List<Activity> findByCreatorIdAndStatus(Long creatorId, BaseStatus status);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
@@ -12,5 +12,7 @@ public interface ActivityRepository extends JpaRepository<Activity, Long>, Activ
 
     Optional<Activity> findByInviteCode(String inviteCode);
 
+    Optional<Activity> findByManagerInviteCode(String managerInviteCode);
+
     List<Activity> findByCreatorIdAndStatus(Long creatorId, BaseStatus status);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/ActivityRepository.java
@@ -19,4 +19,8 @@ public interface ActivityRepository extends JpaRepository<Activity, Long>, Activ
     List<Activity> findByCreatorIdAndStatus(Long creatorId, BaseStatus status);
 
     List<Activity> findByLifecycleStatusAndStartAtBefore(ActivityLifecycleStatus lifecycleStatus, OffsetDateTime startAt);
+
+    List<Activity> findByLifecycleStatusInAndEndAtBefore(List<ActivityLifecycleStatus> statuses, OffsetDateTime endAt);
+
+    List<Activity> findByLifecycleStatusAndEndAtBefore(ActivityLifecycleStatus lifecycleStatus, OffsetDateTime endAt);
 }

--- a/modules/activity/src/main/java/com/dewple/activity/repository/StarRatingRepository.java
+++ b/modules/activity/src/main/java/com/dewple/activity/repository/StarRatingRepository.java
@@ -1,0 +1,25 @@
+package com.dewple.activity.repository;
+
+import com.dewple.activity.entity.StarRating;
+import com.dewple.common.enums.BaseStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+public interface StarRatingRepository extends JpaRepository<StarRating, Long> {
+
+    boolean existsByActivityIdAndRaterIdAndRateeIdAndStatus(
+            Long activityId, Long raterId, Long rateeId, BaseStatus status);
+
+    List<StarRating> findByActivityIdAndRaterIdAndStatus(
+            Long activityId, Long raterId, BaseStatus status);
+
+    @Query("SELECT AVG(sr.score) FROM StarRating sr WHERE sr.ratee.id = :rateeId AND sr.status = :status")
+    Optional<BigDecimal> findAverageScoreByRateeId(@Param("rateeId") Long rateeId, @Param("status") BaseStatus status);
+
+    long countByRateeIdAndStatus(Long rateeId, BaseStatus status);
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityHistoryResult.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityHistoryResult.java
@@ -1,0 +1,14 @@
+package com.dewple.activity.service;
+
+import java.time.OffsetDateTime;
+
+public record ActivityHistoryResult(
+        Long activityId,
+        String activityName,
+        String thumbnailUrl,
+        String createdBy,
+        String clubName,
+        OffsetDateTime startAt,
+        OffsetDateTime endAt
+) {
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityInquiryService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityInquiryService.java
@@ -8,7 +8,6 @@ import com.dewple.activity.repository.ActivityParticipantRepository;
 import com.dewple.activity.repository.ActivityRepository;
 import com.dewple.common.entity.User;
 import com.dewple.common.enums.BaseStatus;
-import com.dewple.common.enums.ParticipantRole;
 import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.repository.UserRepository;
@@ -26,7 +25,7 @@ public class ActivityInquiryService {
 
     private final ActivityRepository activityRepository;
     private final ActivityInquiryRepository inquiryRepository;
-    private final ActivityParticipantRepository participantRepository;
+    private final ActivityPermissionValidator permissionValidator;
     private final UserRepository userRepository;
 
     @Transactional
@@ -82,7 +81,7 @@ public class ActivityInquiryService {
     @Transactional
     public void deleteInquiryByManager(Long userId, Long activityId, Long inquiryId) {
         findActiveActivity(activityId);
-        validateLeaderOrManager(activityId, userId);
+        permissionValidator.validateLeaderOrManager(activityId, userId);
 
         ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
         inquiry.inactivate();
@@ -92,7 +91,7 @@ public class ActivityInquiryService {
     @Transactional
     public void answerInquiry(Long userId, Long activityId, Long inquiryId, String answer) {
         findActiveActivity(activityId);
-        validateLeaderOrManager(activityId, userId);
+        permissionValidator.validateLeaderOrManager(activityId, userId);
 
         ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
 
@@ -106,7 +105,7 @@ public class ActivityInquiryService {
     @Transactional
     public void updateAnswer(Long userId, Long activityId, Long inquiryId, String answer) {
         findActiveActivity(activityId);
-        validateLeaderOrManager(activityId, userId);
+        permissionValidator.validateLeaderOrManager(activityId, userId);
 
         ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
         if (!inquiry.hasAnswer()) {
@@ -148,14 +147,4 @@ public class ActivityInquiryService {
         }
     }
 
-    private void validateLeaderOrManager(Long activityId, Long userId) {
-        boolean isLeaderOrManager = participantRepository.findByActivityIdAndParticipantId(activityId, userId)
-                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
-                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
-                .orElse(false);
-
-        if (!isLeaderOrManager) {
-            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
-        }
-    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityInquiryService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityInquiryService.java
@@ -1,0 +1,161 @@
+package com.dewple.activity.service;
+
+import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityInquiry;
+import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityInquiryRepository;
+import com.dewple.activity.repository.ActivityParticipantRepository;
+import com.dewple.activity.repository.ActivityRepository;
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantRole;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.user.exception.UserErrorCode;
+import com.dewple.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ActivityInquiryService {
+
+    private final ActivityRepository activityRepository;
+    private final ActivityInquiryRepository inquiryRepository;
+    private final ActivityParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ActivityInquiry createInquiry(Long userId, Long activityId, String content, Boolean isAnonymous) {
+        Activity activity = findActiveActivity(activityId);
+
+        User author = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        ActivityInquiry inquiry = ActivityInquiry.builder()
+                .activity(activity)
+                .author(author)
+                .content(content)
+                .isAnonymous(isAnonymous)
+                .build();
+
+        inquiryRepository.save(inquiry);
+        // TODO: 모임장/모임관리자에게 문의 알림 (누적 1/5/10/20/40/80... 도달 시)
+        log.info("모임 문의 작성: inquiryId={}, activityId={}", inquiry.getId(), activityId);
+        return inquiry;
+    }
+
+    @Transactional
+    public void updateInquiry(Long userId, Long activityId, Long inquiryId, String content) {
+        findActiveActivity(activityId);
+
+        ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
+        validateInquiryAuthor(inquiry, userId);
+
+        if (inquiry.hasAnswer()) {
+            throw new BusinessException(ActivityErrorCode.INQUIRY_ALREADY_ANSWERED);
+        }
+
+        inquiry.updateContent(content);
+        log.info("모임 문의 수정: inquiryId={}", inquiryId);
+    }
+
+    @Transactional
+    public void deleteInquiryByAuthor(Long userId, Long activityId, Long inquiryId) {
+        findActiveActivity(activityId);
+
+        ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
+        validateInquiryAuthor(inquiry, userId);
+
+        if (inquiry.hasAnswer()) {
+            throw new BusinessException(ActivityErrorCode.INQUIRY_ALREADY_ANSWERED);
+        }
+
+        inquiry.inactivate();
+        log.info("모임 문의 삭제 (작성자): inquiryId={}", inquiryId);
+    }
+
+    @Transactional
+    public void deleteInquiryByManager(Long userId, Long activityId, Long inquiryId) {
+        findActiveActivity(activityId);
+        validateLeaderOrManager(activityId, userId);
+
+        ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
+        inquiry.inactivate();
+        log.info("모임 문의 삭제 (운영진): inquiryId={}, by userId={}", inquiryId, userId);
+    }
+
+    @Transactional
+    public void answerInquiry(Long userId, Long activityId, Long inquiryId, String answer) {
+        findActiveActivity(activityId);
+        validateLeaderOrManager(activityId, userId);
+
+        ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
+
+        User answerer = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        inquiry.setAnswer(answer, answerer);
+        log.info("모임 문의 답변: inquiryId={}, by userId={}", inquiryId, userId);
+    }
+
+    @Transactional
+    public void updateAnswer(Long userId, Long activityId, Long inquiryId, String answer) {
+        findActiveActivity(activityId);
+        validateLeaderOrManager(activityId, userId);
+
+        ActivityInquiry inquiry = findActiveInquiry(inquiryId, activityId);
+        if (!inquiry.hasAnswer()) {
+            throw new BusinessException(ActivityErrorCode.INQUIRY_NOT_ANSWERED);
+        }
+
+        inquiry.updateAnswer(answer);
+        log.info("모임 문의 답변 수정: inquiryId={}", inquiryId);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ActivityInquiry> getInquiryList(Long activityId, Pageable pageable) {
+        findActiveActivity(activityId);
+        return inquiryRepository.findByActivityIdAndStatusOrderByCreatedAtDesc(
+                activityId, BaseStatus.ACTIVE, pageable);
+    }
+
+    // ========== 헬퍼 ==========
+
+    private Activity findActiveActivity(Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+        return activity;
+    }
+
+    private ActivityInquiry findActiveInquiry(Long inquiryId, Long activityId) {
+        return inquiryRepository.findById(inquiryId)
+                .filter(i -> i.getActivity().getId().equals(activityId))
+                .filter(i -> i.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.INQUIRY_NOT_FOUND));
+    }
+
+    private void validateInquiryAuthor(ActivityInquiry inquiry, Long userId) {
+        if (!inquiry.getAuthor().getId().equals(userId)) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_DELETE_PERMISSION_DENIED);
+        }
+    }
+
+    private void validateLeaderOrManager(Long activityId, Long userId) {
+        boolean isLeaderOrManager = participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
+                .orElse(false);
+
+        if (!isLeaderOrManager) {
+            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityNoticeService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityNoticeService.java
@@ -1,0 +1,179 @@
+package com.dewple.activity.service;
+
+import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityNotice;
+import com.dewple.activity.entity.ActivityNoticeComment;
+import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityNoticeCommentRepository;
+import com.dewple.activity.repository.ActivityNoticeRepository;
+import com.dewple.activity.repository.ActivityParticipantRepository;
+import com.dewple.activity.repository.ActivityRepository;
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantRole;
+import com.dewple.common.enums.ParticipantStatus;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.user.exception.UserErrorCode;
+import com.dewple.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ActivityNoticeService {
+
+    private final ActivityRepository activityRepository;
+    private final ActivityNoticeRepository noticeRepository;
+    private final ActivityNoticeCommentRepository commentRepository;
+    private final ActivityParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ActivityNotice createNotice(Long userId, Long activityId, String title, String content, String imageUrls) {
+        Activity activity = findActiveActivity(activityId);
+        validateLeaderOrManager(activityId, userId);
+
+        User author = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        ActivityNotice notice = ActivityNotice.builder()
+                .activity(activity)
+                .author(author)
+                .title(title)
+                .content(content)
+                .imageUrls(imageUrls)
+                .build();
+
+        noticeRepository.save(notice);
+        // TODO: 참여 확정자에게 공지 알림 발송
+        log.info("모임 공지 생성: noticeId={}, activityId={}", notice.getId(), activityId);
+        return notice;
+    }
+
+    @Transactional
+    public void updateNotice(Long userId, Long activityId, Long noticeId,
+                             String title, String content, String imageUrls) {
+        findActiveActivity(activityId);
+        validateLeaderOrManager(activityId, userId);
+
+        ActivityNotice notice = findActiveNotice(noticeId, activityId);
+        notice.update(title, content, imageUrls);
+        log.info("모임 공지 수정: noticeId={}", noticeId);
+    }
+
+    @Transactional
+    public void deleteNotice(Long userId, Long activityId, Long noticeId) {
+        findActiveActivity(activityId);
+        validateLeaderOrManager(activityId, userId);
+
+        ActivityNotice notice = findActiveNotice(noticeId, activityId);
+        notice.inactivate();
+        log.info("모임 공지 삭제: noticeId={}", noticeId);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ActivityNotice> getNoticeList(Long userId, Long activityId, Pageable pageable) {
+        findActiveActivity(activityId);
+        validateConfirmedParticipant(activityId, userId);
+
+        return noticeRepository.findByActivityIdAndStatusOrderByCreatedAtDesc(
+                activityId, BaseStatus.ACTIVE, pageable);
+    }
+
+    @Transactional
+    public ActivityNoticeComment createComment(Long userId, Long activityId, Long noticeId, String content) {
+        findActiveActivity(activityId);
+        validateConfirmedParticipant(activityId, userId);
+
+        ActivityNotice notice = findActiveNotice(noticeId, activityId);
+        User author = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        ActivityNoticeComment comment = ActivityNoticeComment.builder()
+                .notice(notice)
+                .author(author)
+                .content(content)
+                .build();
+
+        commentRepository.save(comment);
+        notice.increaseCommentCount();
+        // TODO: 댓글 알림 (모임장/관리자에게, 누적 1/5/10/20/40... 도달 시)
+        log.info("모임 공지 댓글 생성: commentId={}, noticeId={}", comment.getId(), noticeId);
+        return comment;
+    }
+
+    @Transactional
+    public void deleteComment(Long userId, Long activityId, Long noticeId, Long commentId) {
+        findActiveActivity(activityId);
+
+        ActivityNoticeComment comment = commentRepository.findById(commentId)
+                .filter(c -> c.getNotice().getId().equals(noticeId))
+                .filter(c -> c.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        boolean isAuthor = comment.getAuthor().getId().equals(userId);
+        boolean isLeaderOrManager = isLeaderOrManager(activityId, userId);
+
+        if (!isAuthor && !isLeaderOrManager) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_DELETE_PERMISSION_DENIED);
+        }
+
+        comment.inactivate();
+        findActiveNotice(noticeId, activityId).decreaseCommentCount();
+        log.info("모임 공지 댓글 삭제: commentId={}", commentId);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ActivityNoticeComment> getCommentList(Long userId, Long activityId,
+                                                       Long noticeId, Pageable pageable) {
+        findActiveActivity(activityId);
+        validateConfirmedParticipant(activityId, userId);
+
+        return commentRepository.findByNoticeIdAndStatusOrderByCreatedAtAsc(
+                noticeId, BaseStatus.ACTIVE, pageable);
+    }
+
+    // ========== 헬퍼 ==========
+
+    private Activity findActiveActivity(Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+        return activity;
+    }
+
+    private ActivityNotice findActiveNotice(Long noticeId, Long activityId) {
+        return noticeRepository.findById(noticeId)
+                .filter(n -> n.getActivity().getId().equals(activityId))
+                .filter(n -> n.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+    }
+
+    private void validateLeaderOrManager(Long activityId, Long userId) {
+        if (!isLeaderOrManager(activityId, userId)) {
+            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+    }
+
+    private void validateConfirmedParticipant(Long activityId, Long userId) {
+        participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .filter(p -> p.getParticipantStatus() == ParticipantStatus.CONFIRMED)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_CONFIRMED));
+    }
+
+    private boolean isLeaderOrManager(Long activityId, Long userId) {
+        return participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
+                .orElse(false);
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityNoticeService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityNoticeService.java
@@ -11,8 +11,6 @@ import com.dewple.activity.repository.ActivityParticipantRepository;
 import com.dewple.activity.repository.ActivityRepository;
 import com.dewple.common.entity.User;
 import com.dewple.common.enums.BaseStatus;
-import com.dewple.common.enums.ParticipantRole;
-import com.dewple.common.enums.ParticipantStatus;
 import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.repository.UserRepository;
@@ -31,13 +29,13 @@ public class ActivityNoticeService {
     private final ActivityRepository activityRepository;
     private final ActivityNoticeRepository noticeRepository;
     private final ActivityNoticeCommentRepository commentRepository;
-    private final ActivityParticipantRepository participantRepository;
+    private final ActivityPermissionValidator permissionValidator;
     private final UserRepository userRepository;
 
     @Transactional
     public ActivityNotice createNotice(Long userId, Long activityId, String title, String content, String imageUrls) {
         Activity activity = findActiveActivity(activityId);
-        validateLeaderOrManager(activityId, userId);
+        permissionValidator.validateLeaderOrManager(activityId, userId);
 
         User author = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
@@ -60,7 +58,7 @@ public class ActivityNoticeService {
     public void updateNotice(Long userId, Long activityId, Long noticeId,
                              String title, String content, String imageUrls) {
         findActiveActivity(activityId);
-        validateLeaderOrManager(activityId, userId);
+        permissionValidator.validateLeaderOrManager(activityId, userId);
 
         ActivityNotice notice = findActiveNotice(noticeId, activityId);
         notice.update(title, content, imageUrls);
@@ -70,7 +68,7 @@ public class ActivityNoticeService {
     @Transactional
     public void deleteNotice(Long userId, Long activityId, Long noticeId) {
         findActiveActivity(activityId);
-        validateLeaderOrManager(activityId, userId);
+        permissionValidator.validateLeaderOrManager(activityId, userId);
 
         ActivityNotice notice = findActiveNotice(noticeId, activityId);
         notice.inactivate();
@@ -80,7 +78,7 @@ public class ActivityNoticeService {
     @Transactional(readOnly = true)
     public Slice<ActivityNotice> getNoticeList(Long userId, Long activityId, Pageable pageable) {
         findActiveActivity(activityId);
-        validateConfirmedParticipant(activityId, userId);
+        permissionValidator.validateConfirmedParticipant(activityId, userId);
 
         return noticeRepository.findByActivityIdAndStatusOrderByCreatedAtDesc(
                 activityId, BaseStatus.ACTIVE, pageable);
@@ -89,7 +87,7 @@ public class ActivityNoticeService {
     @Transactional
     public ActivityNoticeComment createComment(Long userId, Long activityId, Long noticeId, String content) {
         findActiveActivity(activityId);
-        validateConfirmedParticipant(activityId, userId);
+        permissionValidator.validateConfirmedParticipant(activityId, userId);
 
         ActivityNotice notice = findActiveNotice(noticeId, activityId);
         User author = userRepository.findById(userId)
@@ -118,7 +116,7 @@ public class ActivityNoticeService {
                 .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
 
         boolean isAuthor = comment.getAuthor().getId().equals(userId);
-        boolean isLeaderOrManager = isLeaderOrManager(activityId, userId);
+        boolean isLeaderOrManager = permissionValidator.isLeaderOrManager(activityId, userId);
 
         if (!isAuthor && !isLeaderOrManager) {
             throw new BusinessException(ActivityErrorCode.ACTIVITY_DELETE_PERMISSION_DENIED);
@@ -133,7 +131,7 @@ public class ActivityNoticeService {
     public Slice<ActivityNoticeComment> getCommentList(Long userId, Long activityId,
                                                        Long noticeId, Pageable pageable) {
         findActiveActivity(activityId);
-        validateConfirmedParticipant(activityId, userId);
+        permissionValidator.validateConfirmedParticipant(activityId, userId);
 
         return commentRepository.findByNoticeIdAndStatusOrderByCreatedAtAsc(
                 noticeId, BaseStatus.ACTIVE, pageable);
@@ -157,23 +155,4 @@ public class ActivityNoticeService {
                 .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
     }
 
-    private void validateLeaderOrManager(Long activityId, Long userId) {
-        if (!isLeaderOrManager(activityId, userId)) {
-            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
-        }
-    }
-
-    private void validateConfirmedParticipant(Long activityId, Long userId) {
-        participantRepository.findByActivityIdAndParticipantId(activityId, userId)
-                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
-                .filter(p -> p.getParticipantStatus() == ParticipantStatus.CONFIRMED)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_CONFIRMED));
-    }
-
-    private boolean isLeaderOrManager(Long activityId, Long userId) {
-        return participantRepository.findByActivityIdAndParticipantId(activityId, userId)
-                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
-                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
-                .orElse(false);
-    }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityPermissionValidator.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityPermissionValidator.java
@@ -1,0 +1,41 @@
+package com.dewple.activity.service;
+
+import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityParticipantRepository;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantRole;
+import com.dewple.common.enums.ParticipantStatus;
+import com.dewple.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ActivityPermissionValidator {
+
+    private final ActivityParticipantRepository participantRepository;
+
+    public boolean isLeaderOrManager(Long activityId, Long userId) {
+        return participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
+                .orElse(false);
+    }
+
+    public void validateLeaderOrManager(Long activityId, Long userId) {
+        if (!isLeaderOrManager(activityId, userId)) {
+            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+    }
+
+    public void validateConfirmedParticipant(Long activityId, Long userId) {
+        boolean isConfirmed = participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .map(p -> p.getParticipantStatus() == ParticipantStatus.CONFIRMED)
+                .orElse(false);
+
+        if (!isConfirmed) {
+            throw new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_CONFIRMED);
+        }
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityReportService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityReportService.java
@@ -1,0 +1,137 @@
+package com.dewple.activity.service;
+
+import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.entity.ActivityReport;
+import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityParticipantRepository;
+import com.dewple.activity.repository.ActivityReportRepository;
+import com.dewple.activity.repository.ActivityRepository;
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantStatus;
+import com.dewple.common.enums.ReportCategory;
+import com.dewple.common.enums.ReportStatus;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.user.exception.UserErrorCode;
+import com.dewple.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ActivityReportService {
+
+    private static final int REPORT_COOLDOWN_HOURS = 168; // 7일
+
+    private final ActivityRepository activityRepository;
+    private final ActivityReportRepository reportRepository;
+    private final ActivityParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ActivityReport reportActivity(Long userId, Long activityId, ReportCategory category, String reason) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        User reporter = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 중복 신고 체크 (동일 대상, 마지막 신고 후 7일 이내)
+        reportRepository.findTopByActivityIdAndReporterIdOrderByCreatedAtDesc(activityId, userId)
+                .ifPresent(lastReport -> {
+                    OffsetDateTime cooldownEnd = lastReport.getCreatedAt()
+                            .plusHours(REPORT_COOLDOWN_HOURS);
+                    if (OffsetDateTime.now().isBefore(cooldownEnd)) {
+                        throw new BusinessException(ActivityErrorCode.REPORT_COOLDOWN);
+                    }
+                });
+
+        // 모임 정보 스냅샷 생성
+        String snapshot = createSnapshot(activity);
+
+        ActivityReport report = ActivityReport.builder()
+                .activity(activity)
+                .reporter(reporter)
+                .category(category)
+                .reason(reason)
+                .snapshot(snapshot)
+                .build();
+
+        reportRepository.save(report);
+        // TODO: 신고자에게 '접수되었습니다' 알림 발송
+        log.info("모임 신고 접수: reportId={}, activityId={}, by userId={}", report.getId(), activityId, userId);
+        return report;
+    }
+
+    /**
+     * 신고 처리 완료 후 6개월 경과한 스냅샷 자동 삭제.
+     * app-worker 스케줄러에서 주기적으로 호출.
+     */
+    @Transactional
+    public int deleteExpiredSnapshots() {
+        OffsetDateTime sixMonthsAgo = OffsetDateTime.now().minusMonths(6);
+
+        List<ActivityReport> resolved = reportRepository.findByReportStatusAndResolvedAtBefore(
+                ReportStatus.RESOLVED, sixMonthsAgo);
+        List<ActivityReport> dismissed = reportRepository.findByReportStatusAndResolvedAtBefore(
+                ReportStatus.DISMISSED, sixMonthsAgo);
+
+        int count = 0;
+        for (ActivityReport report : resolved) {
+            report.inactivate();
+            count++;
+        }
+        for (ActivityReport report : dismissed) {
+            report.inactivate();
+            count++;
+        }
+
+        if (count > 0) {
+            log.info("만료 신고 스냅샷 삭제: {}건", count);
+        }
+        return count;
+    }
+
+    private String createSnapshot(Activity activity) {
+        long participantCount = participantRepository.countByActivityIdAndStatusAndParticipantStatusIn(
+                activity.getId(), BaseStatus.ACTIVE,
+                List.of(ParticipantStatus.CONFIRMED, ParticipantStatus.APPROVED));
+
+        StringBuilder sb = new StringBuilder("{");
+        sb.append("\"title\":\"").append(escape(activity.getName())).append("\"");
+        sb.append(",\"description\":\"").append(escape(activity.getDescription())).append("\"");
+        sb.append(",\"creatorId\":").append(activity.getCreator().getId());
+        sb.append(",\"creatorNickname\":\"").append(escape(activity.getCreator().getNickname())).append("\"");
+        sb.append(",\"startAt\":\"").append(activity.getStartAt()).append("\"");
+        sb.append(",\"endAt\":\"").append(activity.getEndAt()).append("\"");
+        sb.append(",\"openType\":\"").append(activity.getOpenType().name()).append("\"");
+        sb.append(",\"participantCount\":").append(participantCount);
+
+        if (activity.getClub() != null) {
+            sb.append(",\"createdBy\":\"CLUB\"");
+            sb.append(",\"clubId\":").append(activity.getClub().getId());
+            sb.append(",\"clubName\":\"").append(escape(activity.getClub().getName())).append("\"");
+        } else if (activity.getOrganization() != null) {
+            sb.append(",\"createdBy\":\"ORGANIZATION\"");
+            sb.append(",\"organizationId\":").append(activity.getOrganization().getId());
+            sb.append(",\"organizationName\":\"").append(escape(activity.getOrganization().getName())).append("\"");
+        } else {
+            sb.append(",\"createdBy\":\"PERSONAL\"");
+        }
+
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String escape(String value) {
+        if (value == null) return "";
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -326,6 +326,11 @@ public class ActivityService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
+        long currentCount = activityInterestRepository.countByUserIdAndStatus(userId, BaseStatus.ACTIVE);
+        if (currentCount >= 20) {
+            throw new BusinessException(ActivityErrorCode.INTEREST_LIMIT_EXCEEDED);
+        }
+
         activityInterestRepository.findByActivityIdAndUserId(activityId, userId)
                 .ifPresentOrElse(
                         interest -> {

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -629,6 +629,14 @@ public class ActivityService {
     }
 
     @Transactional(readOnly = true)
+    public Slice<ActivityHistoryResult> getActivityHistory(Long userId, Pageable pageable) {
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+        }
+        return activityParticipantRepository.findActivityHistoryByUserId(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
     public String getInviteCode(Long userId, Long activityId) {
         Activity activity = findActiveActivity(activityId);
 

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -416,6 +416,50 @@ public class ActivityService {
         }
     }
 
+    // ========== 모임 종료 ==========
+
+    /**
+     * 종료 시점(endAt)이 지난 RECRUITING/IN_PROGRESS 모임을 ENDED로 전환.
+     * app-worker 스케줄러에서 주기적으로 호출.
+     */
+    @Transactional
+    public int endActivitiesAutomatically() {
+        List<Activity> candidates = activityRepository.findByLifecycleStatusInAndEndAtBefore(
+                List.of(ActivityLifecycleStatus.RECRUITING, ActivityLifecycleStatus.IN_PROGRESS),
+                OffsetDateTime.now());
+
+        for (Activity activity : candidates) {
+            activity.markEnded();
+            // TODO: 별점 평가 요청 알림 발송 (참여 확정자들에게)
+            // TODO: 지원서 보관 결정 안내 알림 발송
+            // TODO: 출석기록 이관 (동아리/연합회 → 출석부, 개인 → 삭제)
+            // TODO: 참여자의 모임 이력에 자동 기록
+            log.info("모임 종료 처리: activityId={}", activity.getId());
+        }
+
+        return candidates.size();
+    }
+
+    /**
+     * ENDED 상태에서 7일 경과한 모임을 DELETED로 전환.
+     * app-worker 스케줄러에서 주기적으로 호출.
+     */
+    @Transactional
+    public int deleteEndedActivitiesAutomatically() {
+        OffsetDateTime sevenDaysAgo = OffsetDateTime.now().minusDays(7);
+        List<Activity> candidates = activityRepository.findByLifecycleStatusAndEndAtBefore(
+                ActivityLifecycleStatus.ENDED, sevenDaysAgo);
+
+        for (Activity activity : candidates) {
+            activity.markDeleted();
+            // TODO: 보관 미결정 지원서 응답 삭제
+            // TODO: 문의/공지 데이터 삭제
+            log.info("종료 모임 삭제: activityId={}", activity.getId());
+        }
+
+        return candidates.size();
+    }
+
     @Transactional
     public void addActivityInterest(Long userId, Long activityId) {
         Activity activity = findActiveActivity(activityId);

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -17,6 +17,7 @@ import com.dewple.common.entity.Category;
 import com.dewple.common.entity.Club;
 import com.dewple.common.entity.Region;
 import com.dewple.common.entity.User;
+import com.dewple.common.enums.ParticipantRole;
 import com.dewple.common.enums.ParticipantStatus;
 import com.dewple.common.enums.Permission;
 import com.dewple.common.exception.BusinessException;
@@ -107,6 +108,8 @@ public class ActivityService {
             inviteCode = UUID.randomUUID().toString();
         }
 
+        String managerInviteCode = UUID.randomUUID().toString();
+
         Activity activity = Activity.builder()
                 .club(club)
                 .creator(creator)
@@ -126,11 +129,22 @@ public class ActivityService {
                 .maxAge(param.maxAge())
                 .gender(param.gender())
                 .inviteCode(inviteCode)
+                .managerInviteCode(managerInviteCode)
                 .emergencyContact(param.emergencyContact())
                 .cancelDeadlineDays(param.cancelDeadlineDays())
                 .build();
 
         activityRepository.save(activity);
+
+        // 모임장을 LEADER로 참여자 등록 (capacity에 미포함, 별도 카운트)
+        ActivityParticipant leaderParticipant = ActivityParticipant.builder()
+                .activity(activity)
+                .participant(creator)
+                .participantStatus(ParticipantStatus.CONFIRMED)
+                .role(ParticipantRole.LEADER)
+                .build();
+        activityParticipantRepository.save(leaderParticipant);
+
         log.info("모임 생성 완료: activityId={}, creatorId={}", activity.getId(), userId);
 
         return new CreateActivityResult(
@@ -491,5 +505,117 @@ public class ActivityService {
 
         activityParticipantRepository.save(participant);
         log.info("초대 코드로 모임 참여: userId={}, activityId={}", userId, activity.getId());
+    }
+
+    // ========== 모임관리자 ==========
+
+    private static final int MAX_MANAGERS = 50;
+
+    @Transactional(readOnly = true)
+    public String getManagerInviteCode(Long userId, Long activityId) {
+        Activity activity = findActiveActivity(activityId);
+        validateLeader(activity, userId);
+        return activity.getManagerInviteCode();
+    }
+
+    @Transactional
+    public void joinAsManager(Long userId, String managerInviteCode) {
+        Activity activity = activityRepository.findByManagerInviteCode(managerInviteCode)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.INVITE_CODE_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        if (activity.getCreator().getId().equals(userId)) {
+            throw new BusinessException(ActivityErrorCode.CANNOT_JOIN_OWN_ACTIVITY);
+        }
+
+        // 이미 참여자인지 확인
+        activityParticipantRepository.findByActivityIdAndParticipantId(activity.getId(), userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .ifPresent(p -> {
+                    if (p.getRole() == ParticipantRole.MANAGER) {
+                        throw new BusinessException(ActivityErrorCode.ALREADY_MANAGER);
+                    }
+                    throw new BusinessException(ActivityErrorCode.ALREADY_PARTICIPANT);
+                });
+
+        // 매니저 50명 제한
+        long managerCount = activityParticipantRepository.countByActivityIdAndStatusAndRole(
+                activity.getId(), BaseStatus.ACTIVE, ParticipantRole.MANAGER);
+        if (managerCount >= MAX_MANAGERS) {
+            throw new BusinessException(ActivityErrorCode.MANAGER_LIMIT_EXCEEDED);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 모임관리자는 자동 참여 확정 + MANAGER role (capacity에 미포함)
+        ActivityParticipant manager = ActivityParticipant.builder()
+                .activity(activity)
+                .participant(user)
+                .participantStatus(ParticipantStatus.CONFIRMED)
+                .role(ParticipantRole.MANAGER)
+                .build();
+        activityParticipantRepository.save(manager);
+
+        log.info("모임관리자 등록: userId={}, activityId={}", userId, activity.getId());
+    }
+
+    @Transactional
+    public void removeManager(Long userId, Long activityId, Long managerId) {
+        Activity activity = findActiveActivity(activityId);
+        validateLeader(activity, userId);
+
+        ActivityParticipant manager = activityParticipantRepository
+                .findByActivityIdAndParticipantIdAndStatusAndRole(
+                        activityId, managerId, BaseStatus.ACTIVE, ParticipantRole.MANAGER)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.MANAGER_NOT_FOUND));
+
+        // 자격 해제 시 참여 확정도 함께 취소
+        manager.inactivate();
+        log.info("모임관리자 제거: managerId={}, activityId={}", managerId, activityId);
+    }
+
+    @Transactional
+    public void leaveAsManager(Long userId, Long activityId) {
+        Activity activity = findActiveActivity(activityId);
+
+        ActivityParticipant manager = activityParticipantRepository
+                .findByActivityIdAndParticipantIdAndStatusAndRole(
+                        activityId, userId, BaseStatus.ACTIVE, ParticipantRole.MANAGER)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.MANAGER_NOT_FOUND));
+
+        // 자격 해제 시 참여 확정도 함께 취소
+        manager.inactivate();
+        log.info("모임관리자 자발적 탈퇴: userId={}, activityId={}", userId, activityId);
+    }
+
+    // ========== 헬퍼 ==========
+
+    private Activity findActiveActivity(Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+        return activity;
+    }
+
+    private void validateLeader(Activity activity, Long userId) {
+        if (!activity.getCreator().getId().equals(userId)) {
+            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+    }
+
+    /**
+     * 모임장 또는 모임관리자인지 확인
+     */
+    private boolean isLeaderOrManager(Long activityId, Long userId) {
+        return activityParticipantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
+                .orElse(false);
     }
 }

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -17,6 +17,7 @@ import com.dewple.common.entity.Category;
 import com.dewple.common.entity.Club;
 import com.dewple.common.entity.Region;
 import com.dewple.common.entity.User;
+import com.dewple.common.enums.ActivityLifecycleStatus;
 import com.dewple.common.enums.ParticipantRole;
 import com.dewple.common.enums.ParticipantStatus;
 import com.dewple.common.enums.Permission;
@@ -174,12 +175,7 @@ public class ActivityService {
 
     @Transactional
     public void deleteActivity(Long userId, Long activityId) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_ALREADY_INACTIVE);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         boolean isCreator = activity.getCreator().getId().equals(userId);
 
@@ -198,18 +194,13 @@ public class ActivityService {
             }
         }
 
-        activity.inactivate();
-        log.info("모임 삭제 완료: activityId={}, userId={}", activityId, userId);
+        activity.cancel();
+        log.info("모임 삭제(취소) 완료: activityId={}, userId={}", activityId, userId);
     }
 
     @Transactional(readOnly = true)
     public GetActivityDetailResult getActivityDetail(Long activityId) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         List<ActivityParticipant> participants = activityParticipantRepository
                 .findByActivityIdAndStatusWithParticipant(activityId, BaseStatus.ACTIVE);
@@ -253,12 +244,7 @@ public class ActivityService {
 
     @Transactional(readOnly = true)
     public Slice<ParticipantResult> getParticipantList(Long userId, Long activityId, Pageable pageable) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         boolean isCreator = activity.getCreator().getId().equals(userId);
 
@@ -286,12 +272,7 @@ public class ActivityService {
             throw new BusinessException(ActivityErrorCode.INVALID_PARTICIPANT_STATUS);
         }
 
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         boolean isCreator = activity.getCreator().getId().equals(userId);
 
@@ -325,12 +306,7 @@ public class ActivityService {
             throw new BusinessException(ActivityErrorCode.INVALID_PARTICIPATION_RESPONSE);
         }
 
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         ActivityParticipant participant = activityParticipantRepository.findByActivityIdAndParticipantId(activityId, userId)
                 .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
@@ -346,12 +322,7 @@ public class ActivityService {
 
     @Transactional
     public void cancelParticipation(Long userId, Long activityId) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         // #18: 모임 시작 후 취소 불가
         if (activity.getStartAt().isBefore(OffsetDateTime.now())) {
@@ -380,14 +351,74 @@ public class ActivityService {
         log.info("참여 취소: userId={}, activityId={}", userId, activityId);
     }
 
+    // ========== 모임 취소 ==========
+
+    @Transactional
+    public void cancelActivityManually(Long userId, Long activityId) {
+        Activity activity = findActiveActivity(activityId);
+        validateLeader(activity, userId);
+
+        cancelActivity(activity);
+        // TODO: 참여 확정자에게 '모임이 취소되었습니다' 알림 발송
+        // TODO: 대기자에게도 '모임이 취소되었습니다' 알림 발송
+        // TODO: 미확정 지원자에게 '모임이 취소되어 지원이 취소되었습니다' 알림 발송
+        log.info("모임 수동 취소: activityId={}, by userId={}", activityId, userId);
+    }
+
+    /**
+     * 모임 시작 시점이 지났는데 일반 참여자(PARTICIPANT)가 한 명도 CONFIRMED가 아닌 모임을 자동 취소.
+     * app-worker 스케줄러에서 주기적으로 호출.
+     */
+    @Transactional
+    public int cancelActivitiesAutomatically() {
+        List<Activity> candidates = activityRepository.findByLifecycleStatusAndStartAtBefore(
+                ActivityLifecycleStatus.RECRUITING, OffsetDateTime.now());
+
+        int cancelledCount = 0;
+        for (Activity activity : candidates) {
+            // capacity 0명 모임은 자동 취소 대상 제외
+            if (activity.getCapacity() != null && activity.getCapacity() == 0) {
+                continue;
+            }
+
+            // PARTICIPANT role 중 CONFIRMED 상태인 사람이 있는지 확인 (LEADER/MANAGER 제외)
+            long confirmedParticipants = activityParticipantRepository
+                    .countByActivityIdAndStatusAndParticipantStatusAndRole(
+                            activity.getId(), BaseStatus.ACTIVE,
+                            ParticipantStatus.CONFIRMED, ParticipantRole.PARTICIPANT);
+
+            if (confirmedParticipants == 0) {
+                cancelActivity(activity);
+                // TODO: 모임장/모임관리자에게 '참여 확정자가 없어 모임이 자동 취소되었습니다' 알림
+                // TODO: 대기자/미확정 지원자에게 '모임이 취소되었습니다' 알림
+                log.info("모임 자동 취소: activityId={}", activity.getId());
+                cancelledCount++;
+            }
+        }
+        return cancelledCount;
+    }
+
+    private void cancelActivity(Activity activity) {
+        activity.cancel();
+
+        // 해당 모임의 모든 활성 참여자를 CANCELLED 처리
+        List<ActivityParticipant> participants = activityParticipantRepository
+                .findByActivityId(activity.getId()).stream()
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .toList();
+
+        for (ActivityParticipant p : participants) {
+            if (p.getParticipantStatus() != ParticipantStatus.CANCELLED
+                    && p.getParticipantStatus() != ParticipantStatus.REJECTED
+                    && p.getParticipantStatus() != ParticipantStatus.DECLINED) {
+                p.updateParticipantStatus(ParticipantStatus.CANCELLED);
+            }
+        }
+    }
+
     @Transactional
     public void addActivityInterest(Long userId, Long activityId) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
@@ -420,12 +451,7 @@ public class ActivityService {
 
     @Transactional
     public void removeActivityInterest(Long userId, Long activityId) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         ActivityInterest interest = activityInterestRepository.findByActivityIdAndUserId(activityId, userId)
                 .filter(i -> i.getStatus() == BaseStatus.ACTIVE)
@@ -443,12 +469,7 @@ public class ActivityService {
 
     @Transactional(readOnly = true)
     public String getInviteCode(Long userId, Long activityId) {
-        Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        Activity activity = findActiveActivity(activityId);
 
         if (activity.getOpenType() != OpenType.PRIVATE) {
             throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_PRIVATE);
@@ -470,9 +491,7 @@ public class ActivityService {
         Activity activity = activityRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new BusinessException(ActivityErrorCode.INVITE_CODE_NOT_FOUND));
 
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        validateActivityNotCancelledOrDeleted(activity);
 
         if (activity.getCreator().getId().equals(userId)) {
             throw new BusinessException(ActivityErrorCode.CANNOT_JOIN_OWN_ACTIVITY);
@@ -523,9 +542,7 @@ public class ActivityService {
         Activity activity = activityRepository.findByManagerInviteCode(managerInviteCode)
                 .orElseThrow(() -> new BusinessException(ActivityErrorCode.INVITE_CODE_NOT_FOUND));
 
-        if (activity.getStatus() == BaseStatus.INACTIVE) {
-            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
-        }
+        validateActivityNotCancelledOrDeleted(activity);
 
         if (activity.getCreator().getId().equals(userId)) {
             throw new BusinessException(ActivityErrorCode.CANNOT_JOIN_OWN_ACTIVITY);
@@ -600,12 +617,24 @@ public class ActivityService {
         if (activity.getStatus() == BaseStatus.INACTIVE) {
             throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
         }
+        if (activity.getLifecycleStatus() == ActivityLifecycleStatus.CANCELLED
+                || activity.getLifecycleStatus() == ActivityLifecycleStatus.DELETED) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_ALREADY_CANCELLED);
+        }
         return activity;
     }
 
     private void validateLeader(Activity activity, Long userId) {
         if (!activity.getCreator().getId().equals(userId)) {
             throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+    }
+
+    private void validateActivityNotCancelledOrDeleted(Activity activity) {
+        if (activity.getStatus() == BaseStatus.INACTIVE
+                || activity.getLifecycleStatus() == ActivityLifecycleStatus.CANCELLED
+                || activity.getLifecycleStatus() == ActivityLifecycleStatus.DELETED) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
         }
     }
 

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -50,10 +50,18 @@ public class ActivityService {
     private final CategoryRepository categoryRepository;
     private final RegionRepository regionRepository;
 
+    private static final int MAX_LEADER_ACTIVITIES = 10;
+
     @Transactional
     public CreateActivityResult createActivity(Long userId, CreateActivityParam param) {
         User creator = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // #25: 모임장 동시 운영 최대 10개
+        long leaderCount = activityRepository.findByCreatorIdAndStatus(userId, BaseStatus.ACTIVE).size();
+        if (leaderCount >= MAX_LEADER_ACTIVITIES) {
+            throw new BusinessException(ActivityErrorCode.LEADER_ACTIVITY_LIMIT_EXCEEDED);
+        }
 
         if (param.endAt().isBefore(param.startAt()) || param.endAt().isEqual(param.startAt())) {
             throw new BusinessException(ActivityErrorCode.ACTIVITY_END_BEFORE_START);
@@ -61,6 +69,12 @@ public class ActivityService {
 
         if (param.startAt().isBefore(OffsetDateTime.now())) {
             throw new BusinessException(ActivityErrorCode.ACTIVITY_START_IN_PAST);
+        }
+
+        // #23: capacity 0명이면 PRIVATE 자동 전환
+        OpenType resolvedOpenType = param.openType();
+        if (param.capacity() != null && param.capacity() == 0) {
+            resolvedOpenType = OpenType.PRIVATE;
         }
 
         Club club = null;
@@ -89,14 +103,14 @@ public class ActivityService {
         }
 
         String inviteCode = null;
-        if (param.openType() == OpenType.PRIVATE && param.clubId() == null) {
+        if (resolvedOpenType == OpenType.PRIVATE && param.clubId() == null) {
             inviteCode = UUID.randomUUID().toString();
         }
 
         Activity activity = Activity.builder()
                 .club(club)
                 .creator(creator)
-                .openType(param.openType())
+                .openType(resolvedOpenType)
                 .name(param.name())
                 .description(param.description())
                 .capacity(param.capacity())
@@ -112,6 +126,8 @@ public class ActivityService {
                 .maxAge(param.maxAge())
                 .gender(param.gender())
                 .inviteCode(inviteCode)
+                .emergencyContact(param.emergencyContact())
+                .cancelDeadlineDays(param.cancelDeadlineDays())
                 .build();
 
         activityRepository.save(activity);
@@ -312,6 +328,42 @@ public class ActivityService {
 
         participant.updateParticipantStatus(status);
         log.info("모임 참여 응답: userId={}, activityId={}, status={}", userId, activityId, status);
+    }
+
+    @Transactional
+    public void cancelParticipation(Long userId, Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getStatus() == BaseStatus.INACTIVE) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        // #18: 모임 시작 후 취소 불가
+        if (activity.getStartAt().isBefore(OffsetDateTime.now())) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_ALREADY_STARTED);
+        }
+
+        // #18: cancelDeadlineDays 기반 기한 체크
+        OffsetDateTime cancelDeadline = activity.getStartAt()
+                .minusDays(activity.getCancelDeadlineDays());
+        if (OffsetDateTime.now().isAfter(cancelDeadline)) {
+            throw new BusinessException(ActivityErrorCode.CANCEL_DEADLINE_EXCEEDED);
+        }
+
+        ActivityParticipant participant = activityParticipantRepository
+                .findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_FOUND));
+
+        if (participant.getParticipantStatus() != ParticipantStatus.CONFIRMED
+                && participant.getParticipantStatus() != ParticipantStatus.APPROVED) {
+            throw new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_CONFIRMED);
+        }
+
+        participant.updateParticipantStatus(ParticipantStatus.CANCELLED);
+        // TODO: 선착순 모임이면 차순위 대기자 자동 승격 + 알림
+        log.info("참여 취소: userId={}, activityId={}", userId, activityId);
     }
 
     @Transactional

--- a/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/ActivityService.java
@@ -347,8 +347,114 @@ public class ActivityService {
         }
 
         participant.updateParticipantStatus(ParticipantStatus.CANCELLED);
-        // TODO: 선착순 모임이면 차순위 대기자 자동 승격 + 알림
+
+        if (!activity.getHasApplicationForm()) {
+            promoteFromWaitlist(activity);
+        }
+
         log.info("참여 취소: userId={}, activityId={}", userId, activityId);
+    }
+
+    // ========== 선착순 대기열 ==========
+
+    @Transactional
+    public void applyFirstCome(Long userId, Long activityId) {
+        Activity activity = findActiveActivity(activityId);
+
+        if (activity.getHasApplicationForm()) {
+            throw new BusinessException(ActivityErrorCode.NOT_FIRST_COME_ACTIVITY);
+        }
+        if (activity.getStartAt().isBefore(OffsetDateTime.now())) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_ALREADY_STARTED);
+        }
+        if (activity.getCreator().getId().equals(userId)) {
+            throw new BusinessException(ActivityErrorCode.CANNOT_JOIN_OWN_ACTIVITY);
+        }
+
+        activityParticipantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .ifPresent(p -> { throw new BusinessException(ActivityErrorCode.ALREADY_PARTICIPANT); });
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        long confirmedCount = activityParticipantRepository
+                .countByActivityIdAndStatusAndParticipantStatusInAndRole(
+                        activityId, BaseStatus.ACTIVE,
+                        List.of(ParticipantStatus.CONFIRMED), ParticipantRole.PARTICIPANT);
+
+        boolean withinCapacity = activity.getCapacity() == null || confirmedCount < activity.getCapacity();
+
+        if (withinCapacity) {
+            activityParticipantRepository.save(ActivityParticipant.builder()
+                    .activity(activity).participant(user)
+                    .participantStatus(ParticipantStatus.CONFIRMED)
+                    .role(ParticipantRole.PARTICIPANT).build());
+            log.info("선착순 즉시 확정: userId={}, activityId={}", userId, activityId);
+        } else {
+            int nextOrder = activityParticipantRepository
+                    .findFirstByActivityIdAndStatusAndRoleOrderByWaitlistOrderDesc(
+                            activityId, BaseStatus.ACTIVE, ParticipantRole.PARTICIPANT)
+                    .map(p -> p.getWaitlistOrder() != null ? p.getWaitlistOrder() + 1 : 1)
+                    .orElse(1);
+
+            activityParticipantRepository.save(ActivityParticipant.builder()
+                    .activity(activity).participant(user)
+                    .participantStatus(ParticipantStatus.PENDING)
+                    .role(ParticipantRole.PARTICIPANT).waitlistOrder(nextOrder).build());
+            log.info("선착순 대기열 등록: userId={}, activityId={}, order={}", userId, activityId, nextOrder);
+        }
+    }
+
+    @Transactional
+    public void cancelWaitlist(Long userId, Long activityId) {
+        findActiveActivity(activityId);
+
+        ActivityParticipant participant = activityParticipantRepository
+                .findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .filter(p -> p.getParticipantStatus() == ParticipantStatus.PENDING)
+                .filter(p -> p.getWaitlistOrder() != null)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.NOT_IN_WAITLIST));
+
+        participant.updateParticipantStatus(ParticipantStatus.CANCELLED);
+        log.info("대기열 취소: userId={}, activityId={}", userId, activityId);
+    }
+
+    @Transactional
+    public void selectFromWaitlist(Long userId, Long activityId, Long participantId) {
+        Activity activity = findActiveActivity(activityId);
+
+        if (!isLeaderOrManager(activityId, userId)) {
+            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+        if (!activity.getIsVerificationRequired()) {
+            throw new BusinessException(ActivityErrorCode.VERIFICATION_REQUIRED_FOR_SELECT);
+        }
+
+        ActivityParticipant participant = activityParticipantRepository.findById(participantId)
+                .filter(p -> p.getActivity().getId().equals(activityId))
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .filter(p -> p.getParticipantStatus() == ParticipantStatus.PENDING)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.NOT_IN_WAITLIST));
+
+        participant.updateParticipantStatus(ParticipantStatus.CONFIRMED);
+        participant.clearWaitlistOrder();
+        log.info("대기자 선택 참여: participantId={}, activityId={}", participantId, activityId);
+    }
+
+    private void promoteFromWaitlist(Activity activity) {
+        activityParticipantRepository
+                .findFirstByActivityIdAndStatusAndParticipantStatusAndRoleOrderByWaitlistOrderAsc(
+                        activity.getId(), BaseStatus.ACTIVE,
+                        ParticipantStatus.PENDING, ParticipantRole.PARTICIPANT)
+                .ifPresent(next -> {
+                    next.updateParticipantStatus(ParticipantStatus.CONFIRMED);
+                    next.clearWaitlistOrder();
+                    // TODO: 승격된 대기자에게 알림 (푸시+알림톡)
+                    log.info("대기자 자동 승격: userId={}, activityId={}",
+                            next.getParticipant().getId(), activity.getId());
+                });
     }
 
     // ========== 모임 취소 ==========
@@ -430,11 +536,22 @@ public class ActivityService {
 
         for (Activity activity : candidates) {
             activity.markEnded();
+
+            // 대기열 소멸
+            List<ActivityParticipant> waitlist = activityParticipantRepository
+                    .findByActivityIdAndStatusAndParticipantStatusAndRoleOrderByWaitlistOrderAsc(
+                            activity.getId(), BaseStatus.ACTIVE,
+                            ParticipantStatus.PENDING, ParticipantRole.PARTICIPANT);
+            for (ActivityParticipant waiter : waitlist) {
+                waiter.updateParticipantStatus(ParticipantStatus.CANCELLED);
+                // TODO: 대기자에게 '대기가 종료되었습니다' 알림
+            }
+
             // TODO: 별점 평가 요청 알림 발송 (참여 확정자들에게)
             // TODO: 지원서 보관 결정 안내 알림 발송
             // TODO: 출석기록 이관 (동아리/연합회 → 출석부, 개인 → 삭제)
             // TODO: 참여자의 모임 이력에 자동 기록
-            log.info("모임 종료 처리: activityId={}", activity.getId());
+            log.info("모임 종료 처리: activityId={}, 대기열 소멸 {}명", activity.getId(), waitlist.size());
         }
 
         return candidates.size();

--- a/modules/activity/src/main/java/com/dewple/activity/service/CreateActivityParam.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/CreateActivityParam.java
@@ -16,6 +16,8 @@ public record CreateActivityParam(
         Boolean isSearchable,
         OffsetDateTime startAt,
         OffsetDateTime endAt,
+        String emergencyContact,
+        Integer cancelDeadlineDays,
         Long categoryId,
         Long regionId,
         ActivityType activityType,

--- a/modules/activity/src/main/java/com/dewple/activity/service/StarRatingService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/StarRatingService.java
@@ -1,0 +1,184 @@
+package com.dewple.activity.service;
+
+import com.dewple.activity.entity.Activity;
+import com.dewple.activity.entity.ActivityParticipant;
+import com.dewple.activity.entity.StarRating;
+import com.dewple.activity.exception.ActivityErrorCode;
+import com.dewple.activity.repository.ActivityParticipantRepository;
+import com.dewple.activity.repository.ActivityRepository;
+import com.dewple.activity.repository.StarRatingRepository;
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.ActivityLifecycleStatus;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.enums.ParticipantRole;
+import com.dewple.common.enums.ParticipantStatus;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.user.exception.UserErrorCode;
+import com.dewple.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StarRatingService {
+
+    private static final int RATING_PERIOD_DAYS = 7;
+
+    private final ActivityRepository activityRepository;
+    private final ActivityParticipantRepository participantRepository;
+    private final StarRatingRepository starRatingRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void rateParticipant(Long raterId, Long activityId, Long rateeId, BigDecimal score) {
+        if (raterId.equals(rateeId)) {
+            throw new BusinessException(ActivityErrorCode.CANNOT_RATE_SELF);
+        }
+
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        validateRatingPeriod(activity);
+        validateConfirmedParticipant(activityId, raterId);
+        validateConfirmedParticipant(activityId, rateeId);
+
+        if (starRatingRepository.existsByActivityIdAndRaterIdAndRateeIdAndStatus(
+                activityId, raterId, rateeId, BaseStatus.ACTIVE)) {
+            throw new BusinessException(ActivityErrorCode.ALREADY_RATED);
+        }
+
+        if (score.compareTo(BigDecimal.ZERO) < 0 || score.compareTo(BigDecimal.valueOf(5)) > 0) {
+            throw new BusinessException(ActivityErrorCode.INVALID_RATING_SCORE);
+        }
+
+        User rater = userRepository.findById(raterId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User ratee = userRepository.findById(rateeId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // No-show 여부 확인
+        boolean isNoShow = participantRepository.findByActivityIdAndParticipantId(activityId, rateeId)
+                .map(ActivityParticipant::getParticipantStatus)
+                .map(s -> s == ParticipantStatus.NO_SHOW)
+                .orElse(false);
+
+        StarRating rating = StarRating.builder()
+                .activity(activity)
+                .rater(rater)
+                .ratee(ratee)
+                .score(score)
+                .isNoShow(isNoShow)
+                .build();
+
+        starRatingRepository.save(rating);
+        updateReputationScore(rateeId);
+
+        log.info("별점 평가: raterId={}, rateeId={}, activityId={}, score={}", raterId, rateeId, activityId, score);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RatingTargetResult> getRatingTargets(Long userId, Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        validateRatingPeriod(activity);
+
+        List<ActivityParticipant> allConfirmed = participantRepository
+                .findByActivityIdAndStatusAndParticipantStatusAndRole(
+                        activityId, BaseStatus.ACTIVE, ParticipantStatus.CONFIRMED, ParticipantRole.PARTICIPANT);
+
+        // LEADER/MANAGER도 포함
+        allConfirmed.addAll(participantRepository
+                .findByActivityIdAndStatusAndParticipantStatusAndRole(
+                        activityId, BaseStatus.ACTIVE, ParticipantStatus.CONFIRMED, ParticipantRole.LEADER));
+        allConfirmed.addAll(participantRepository
+                .findByActivityIdAndStatusAndParticipantStatusAndRole(
+                        activityId, BaseStatus.ACTIVE, ParticipantStatus.CONFIRMED, ParticipantRole.MANAGER));
+
+        List<StarRating> myRatings = starRatingRepository.findByActivityIdAndRaterIdAndStatus(
+                activityId, userId, BaseStatus.ACTIVE);
+
+        List<Long> alreadyRatedIds = myRatings.stream()
+                .map(r -> r.getRatee().getId())
+                .toList();
+
+        return allConfirmed.stream()
+                .filter(p -> !p.getParticipant().getId().equals(userId))
+                .map(p -> new RatingTargetResult(
+                        p.getParticipant().getId(),
+                        p.getParticipant().getName(),
+                        p.getParticipant().getProfileImg(),
+                        alreadyRatedIds.contains(p.getParticipant().getId()),
+                        p.getParticipantStatus() == ParticipantStatus.NO_SHOW
+                ))
+                .toList();
+    }
+
+    @Transactional
+    public void markNoShow(Long userId, Long activityId, Long participantId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        if (activity.getLifecycleStatus() != ActivityLifecycleStatus.ENDED) {
+            throw new BusinessException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        boolean isLeaderOrManager = participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .map(p -> p.getRole() == ParticipantRole.LEADER || p.getRole() == ParticipantRole.MANAGER)
+                .orElse(false);
+
+        if (!isLeaderOrManager) {
+            throw new BusinessException(ActivityErrorCode.NOT_ACTIVITY_LEADER);
+        }
+
+        ActivityParticipant participant = participantRepository
+                .findByActivityIdAndParticipantId(activityId, participantId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_FOUND));
+
+        participant.updateParticipantStatus(ParticipantStatus.NO_SHOW);
+        log.info("No-show 지정: participantId={}, activityId={}", participantId, activityId);
+    }
+
+    private void validateRatingPeriod(Activity activity) {
+        if (activity.getLifecycleStatus() != ActivityLifecycleStatus.ENDED) {
+            throw new BusinessException(ActivityErrorCode.RATING_NOT_AVAILABLE);
+        }
+        if (activity.getEndAt().plusDays(RATING_PERIOD_DAYS).isBefore(OffsetDateTime.now())) {
+            throw new BusinessException(ActivityErrorCode.RATING_PERIOD_EXPIRED);
+        }
+    }
+
+    private void validateConfirmedParticipant(Long activityId, Long userId) {
+        participantRepository.findByActivityIdAndParticipantId(activityId, userId)
+                .filter(p -> p.getStatus() == BaseStatus.ACTIVE)
+                .filter(p -> p.getParticipantStatus() == ParticipantStatus.CONFIRMED
+                        || p.getParticipantStatus() == ParticipantStatus.NO_SHOW)
+                .orElseThrow(() -> new BusinessException(ActivityErrorCode.PARTICIPANT_NOT_CONFIRMED));
+    }
+
+    private void updateReputationScore(Long userId) {
+        starRatingRepository.findAverageScoreByRateeId(userId, BaseStatus.ACTIVE)
+                .ifPresent(avg -> {
+                    // 소수점 1자리, 올림
+                    BigDecimal rounded = avg.setScale(1, RoundingMode.CEILING);
+                    User user = userRepository.findById(userId)
+                            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+                    user.updateReputationScore(rounded);
+                });
+    }
+
+    public record RatingTargetResult(
+            Long userId, String name, String profileImg,
+            boolean alreadyRated, boolean isNoShow
+    ) {}
+}

--- a/modules/activity/src/main/java/com/dewple/activity/service/StarRatingService.java
+++ b/modules/activity/src/main/java/com/dewple/activity/service/StarRatingService.java
@@ -59,6 +59,11 @@ public class StarRatingService {
             throw new BusinessException(ActivityErrorCode.INVALID_RATING_SCORE);
         }
 
+        // 0.1단위 검증 (소수점 둘째자리 이하 불가)
+        if (score.stripTrailingZeros().scale() > 1) {
+            throw new BusinessException(ActivityErrorCode.INVALID_RATING_SCORE);
+        }
+
         User rater = userRepository.findById(raterId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         User ratee = userRepository.findById(rateeId)

--- a/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
+++ b/modules/activity/src/test/java/com/dewple/activity/service/ActivityServiceTest.java
@@ -117,7 +117,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     null, OpenType.PUBLIC, "봄맞이 독서 모임", "함께 책을 읽어요",
                     20, false, true, START_AT, END_AT,
-                    1L, 1L, ActivityType.OFFLINE, true, 20, 30, Gender.ANY
+                    "010-1234-5678", 1, 1L, 1L, ActivityType.OFFLINE, true, 20, 30, Gender.ANY
             );
 
             // when
@@ -181,7 +181,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     CLUB_ID, OpenType.PRIVATE, "동아리 정기 모임", "이번 주 정기 모임입니다",
                     null, true, false, START_AT, END_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when
@@ -219,7 +219,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     null, OpenType.PUBLIC, "오픈 모임", "누구나 환영",
                     null, null, null, START_AT, END_AT,
-                    null, null, null, null, null, null, null
+                    null, null, null, null, null, null, null, null, null
             );
 
             // when
@@ -243,7 +243,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     null, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, START_AT, END_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -265,7 +265,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     null, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, END_AT, START_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -288,7 +288,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     null, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, sameTime, sameTime,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -312,7 +312,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     null, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, pastStart, futureEnd,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -335,7 +335,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     999L, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, START_AT, END_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -364,7 +364,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     CLUB_ID, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, START_AT, END_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -399,7 +399,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     CLUB_ID, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, START_AT, END_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -440,7 +440,7 @@ class ActivityServiceTest {
             CreateActivityParam param = new CreateActivityParam(
                     CLUB_ID, OpenType.PUBLIC, "모임", "설명",
                     10, false, true, START_AT, END_AT,
-                    null, null, ActivityType.BOTH, false, null, null, Gender.ANY
+                    "010-1234-5678", 1, null, null, ActivityType.BOTH, false, null, null, Gender.ANY
             );
 
             // when & then
@@ -572,7 +572,7 @@ class ActivityServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
-                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_ALREADY_INACTIVE);
+                        assertThat(be.getErrorCode()).isEqualTo(ActivityErrorCode.ACTIVITY_NOT_FOUND);
                     });
         }
 

--- a/modules/club/src/main/java/com/dewple/club/entity/ClubMember.java
+++ b/modules/club/src/main/java/com/dewple/club/entity/ClubMember.java
@@ -63,4 +63,8 @@ public class ClubMember extends BaseEntity {
     public void changeRole(ClubRole role) {
         this.role = role;
     }
+
+    public void updateActivityStatus(ActivityStatus activityStatus) {
+        this.activityStatus = activityStatus;
+    }
 }

--- a/modules/club/src/main/java/com/dewple/club/entity/ClubMember.java
+++ b/modules/club/src/main/java/com/dewple/club/entity/ClubMember.java
@@ -59,4 +59,8 @@ public class ClubMember extends BaseEntity {
         this.activityStatus = activityStatus != null ? activityStatus : ActivityStatus.ACTIVE;
         this.activityEndDate = activityEndDate;
     }
+
+    public void changeRole(ClubRole role) {
+        this.role = role;
+    }
 }

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
@@ -2,9 +2,11 @@ package com.dewple.club.repository;
 
 import com.dewple.club.entity.ClubMember;
 import com.dewple.common.enums.ActivityStatus;
+import com.dewple.common.enums.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +14,9 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     Optional<ClubMember> findByClubIdAndUserId(Long clubId, Long userId);
     Optional<ClubMember> findByClubIdAndUserIdAndActivityStatus(Long clubId, Long userId, ActivityStatus activityStatus);
+
+    List<ClubMember> findByUserIdAndStatusAndActivityStatus(Long userId, BaseStatus status, ActivityStatus activityStatus);
+
+    List<ClubMember> findByClubIdAndStatusAndActivityStatusAndUserIdNot(
+            Long clubId, BaseStatus status, ActivityStatus activityStatus, Long userId);
 }

--- a/modules/common/src/main/java/com/dewple/common/entity/User.java
+++ b/modules/common/src/main/java/com/dewple/common/entity/User.java
@@ -134,6 +134,39 @@ public class User extends BaseEntity {
         this.phone = phone;
     }
 
+    public void updateLastLoginAt() {
+        this.lastLoginAt = OffsetDateTime.now();
+    }
+
+    public void markAsDeleted() {
+        this.deletedAt = OffsetDateTime.now();
+        this.inactivate();
+    }
+
+    public void cancelDeletion() {
+        this.deletedAt = null;
+        this.activate();
+    }
+
+    public boolean isInDeletionPeriod() {
+        return this.deletedAt != null
+                && OffsetDateTime.now().isBefore(this.deletedAt.plusDays(7));
+    }
+
+    public void changeUserId(String newUserId) {
+        this.userId = newUserId;
+        this.userIdChangedAt = OffsetDateTime.now();
+    }
+
+    public boolean canChangeUserId() {
+        if (this.userIdChangedAt == null) return true;
+        return OffsetDateTime.now().isAfter(this.userIdChangedAt.plusDays(7));
+    }
+
+    public void markEmailVerified() {
+        this.isEmailVerified = true;
+    }
+
     public void editProfile(String nickname, String email, LocalDate birthdate,
                             Gender gender, University university, Boolean isGraduated,
                             String workplace, String profileImg, String selfIntroduction,

--- a/modules/common/src/main/java/com/dewple/common/entity/User.java
+++ b/modules/common/src/main/java/com/dewple/common/entity/User.java
@@ -142,6 +142,10 @@ public class User extends BaseEntity {
         this.lastLoginAt = OffsetDateTime.now();
     }
 
+    public void updateReputationScore(BigDecimal score) {
+        this.reputationScore = score;
+    }
+
     public void markAsDeleted() {
         this.deletedAt = OffsetDateTime.now();
         this.inactivate();

--- a/modules/common/src/main/java/com/dewple/common/entity/User.java
+++ b/modules/common/src/main/java/com/dewple/common/entity/User.java
@@ -134,6 +134,10 @@ public class User extends BaseEntity {
         this.phone = phone;
     }
 
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void updateLastLoginAt() {
         this.lastLoginAt = OffsetDateTime.now();
     }

--- a/modules/common/src/main/java/com/dewple/common/enums/ActivityLifecycleStatus.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ActivityLifecycleStatus.java
@@ -1,0 +1,9 @@
+package com.dewple.common.enums;
+
+public enum ActivityLifecycleStatus {
+    RECRUITING,   // 모집 중
+    IN_PROGRESS,  // 진행 중 (모임 기간 내)
+    ENDED,        // 종료 (1주일 뒤 삭제 대기, 별점 평가 기간)
+    CANCELLED,    // 취소됨 (자동/수동/제재 — 이력에 안 남음)
+    DELETED       // 삭제 완료 (종료 후 1주일 경과)
+}

--- a/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
@@ -5,5 +5,6 @@ public enum ParticipantStatus {
     APPROVED,
     REJECTED,
     CONFIRMED,
-    DECLINED
+    DECLINED,
+    CANCELLED
 }

--- a/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ParticipantStatus.java
@@ -6,5 +6,6 @@ public enum ParticipantStatus {
     REJECTED,
     CONFIRMED,
     DECLINED,
-    CANCELLED
+    CANCELLED,
+    NO_SHOW
 }

--- a/modules/common/src/main/java/com/dewple/common/enums/ReportCategory.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ReportCategory.java
@@ -1,0 +1,9 @@
+package com.dewple.common.enums;
+
+public enum ReportCategory {
+    INAPPROPRIATE_CONTENT,
+    ILLEGAL_ACTIVITY,
+    FRAUD,
+    BULLYING,
+    OTHER
+}

--- a/modules/common/src/main/java/com/dewple/common/enums/ReportStatus.java
+++ b/modules/common/src/main/java/com/dewple/common/enums/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.dewple.common.enums;
+
+public enum ReportStatus {
+    PENDING,
+    RESOLVED,
+    DISMISSED
+}

--- a/modules/user/src/main/java/com/dewple/user/entity/PersonalFile.java
+++ b/modules/user/src/main/java/com/dewple/user/entity/PersonalFile.java
@@ -1,0 +1,46 @@
+package com.dewple.user.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "personal_file")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "original_name", nullable = false, length = 500)
+    private String originalName;
+
+    @Column(name = "stored_key", nullable = false, length = 1000)
+    private String storedKey;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Builder
+    public PersonalFile(User user, String originalName, String storedKey,
+                        Long fileSize, String contentType) {
+        this.user = user;
+        this.originalName = originalName;
+        this.storedKey = storedKey;
+        this.fileSize = fileSize;
+        this.contentType = contentType;
+    }
+}

--- a/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
+++ b/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
@@ -38,9 +38,15 @@ public enum UserErrorCode implements ErrorCode {
     REFRESH_TOKEN_INVALID(4301, HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_EXPIRED(4302, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
 
+    USER_IN_DELETION(4204, HttpStatus.FORBIDDEN, "탈퇴가 진행 중인 계정입니다."),
+
     // 4400: 프로필 수정 관련 오류
     CATEGORY_NOT_FOUND(4400, HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
     PHONE_SAME_AS_CURRENT(4401, HttpStatus.BAD_REQUEST, "현재 사용 중인 전화번호와 동일합니다."),
+    USER_ID_CHANGE_COOLDOWN(4402, HttpStatus.BAD_REQUEST, "아이디 변경은 7일에 한 번만 가능합니다."),
+    KAKAO_ONLY_NO_USER_ID(4405, HttpStatus.BAD_REQUEST, "카카오 로그인 전용 계정입니다. 자체 회원가입을 먼저 진행해주세요."),
+    EMAIL_VERIFICATION_REQUIRED(4403, HttpStatus.BAD_REQUEST, "이메일 인증이 필요합니다."),
+    INTEREST_LIMIT_EXCEEDED(4404, HttpStatus.BAD_REQUEST, "관심 설정은 최대 20개까지 가능합니다."),
     ;
 
     private final int code;

--- a/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
+++ b/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
@@ -48,6 +48,11 @@ public enum UserErrorCode implements ErrorCode {
     KAKAO_ONLY_NO_USER_ID(4405, HttpStatus.BAD_REQUEST, "카카오 로그인 전용 계정입니다. 자체 회원가입을 먼저 진행해주세요."),
     EMAIL_VERIFICATION_REQUIRED(4403, HttpStatus.BAD_REQUEST, "이메일 인증이 필요합니다."),
     INTEREST_LIMIT_EXCEEDED(4404, HttpStatus.BAD_REQUEST, "관심 설정은 최대 20개까지 가능합니다."),
+
+    // 4500: 개인 자료실 관련 오류
+    FILE_NOT_FOUND(4500, HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+    STORAGE_LIMIT_EXCEEDED(4501, HttpStatus.BAD_REQUEST, "저장 용량을 초과했습니다. 스토리지를 추가 구매해주세요."),
+    FILE_UPLOAD_FAILED(4502, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     ;
 
     private final int code;

--- a/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
+++ b/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
@@ -24,7 +24,6 @@ public enum UserErrorCode implements ErrorCode {
     // 4100: 회원가입 관련 오류
     PHONE_ALREADY_EXISTS(4101, HttpStatus.CONFLICT, "이미 가입된 전화번호입니다."),
     USER_ID_ALREADY_EXISTS(4102, HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
-    NICKNAME_ALREADY_EXISTS(4103, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     EMAIL_ALREADY_EXISTS(4104, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     WITHDRAWAL_COOLDOWN(4105, HttpStatus.BAD_REQUEST, "탈퇴 후 7일이 지나야 재가입이 가능합니다."),
     PASSWORD_CONFIRM_MISMATCH(4106, HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),

--- a/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
+++ b/modules/user/src/main/java/com/dewple/user/exception/UserErrorCode.java
@@ -38,6 +38,8 @@ public enum UserErrorCode implements ErrorCode {
     REFRESH_TOKEN_EXPIRED(4302, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
 
     USER_IN_DELETION(4204, HttpStatus.FORBIDDEN, "탈퇴가 진행 중인 계정입니다."),
+    KAKAO_ONLY_NO_PASSWORD(4205, HttpStatus.BAD_REQUEST, "카카오 로그인 전용 계정입니다. 카카오 로그인을 이용해주세요."),
+    USER_NOT_FOUND_BY_PHONE(4206, HttpStatus.NOT_FOUND, "해당 전화번호로 가입된 계정을 찾을 수 없습니다."),
 
     // 4400: 프로필 수정 관련 오류
     CATEGORY_NOT_FOUND(4400, HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),

--- a/modules/user/src/main/java/com/dewple/user/port/FileStoragePort.java
+++ b/modules/user/src/main/java/com/dewple/user/port/FileStoragePort.java
@@ -1,0 +1,12 @@
+package com.dewple.user.port;
+
+import java.io.InputStream;
+
+public interface FileStoragePort {
+
+    String upload(String key, InputStream inputStream, long contentLength, String contentType);
+
+    String generateDownloadUrl(String key);
+
+    void delete(String key);
+}

--- a/modules/user/src/main/java/com/dewple/user/port/SmsVerificationPort.java
+++ b/modules/user/src/main/java/com/dewple/user/port/SmsVerificationPort.java
@@ -7,4 +7,6 @@ package com.dewple.user.port;
 public interface SmsVerificationPort {
 
     void sendVerificationCode(String phone, String code);
+
+    void sendTemporaryPassword(String phone, String temporaryPassword);
 }

--- a/modules/user/src/main/java/com/dewple/user/port/WithdrawalActivityPort.java
+++ b/modules/user/src/main/java/com/dewple/user/port/WithdrawalActivityPort.java
@@ -1,0 +1,8 @@
+package com.dewple.user.port;
+
+public interface WithdrawalActivityPort {
+
+    void cancelConfirmedParticipations(Long userId);
+
+    void transferOrCancelLeaderActivities(Long userId);
+}

--- a/modules/user/src/main/java/com/dewple/user/port/WithdrawalClubPort.java
+++ b/modules/user/src/main/java/com/dewple/user/port/WithdrawalClubPort.java
@@ -3,4 +3,6 @@ package com.dewple.user.port;
 public interface WithdrawalClubPort {
 
     void transferPresidentRoles(Long userId);
+
+    void removeFromAllClubs(Long userId);
 }

--- a/modules/user/src/main/java/com/dewple/user/port/WithdrawalClubPort.java
+++ b/modules/user/src/main/java/com/dewple/user/port/WithdrawalClubPort.java
@@ -1,0 +1,6 @@
+package com.dewple.user.port;
+
+public interface WithdrawalClubPort {
+
+    void transferPresidentRoles(Long userId);
+}

--- a/modules/user/src/main/java/com/dewple/user/repository/PersonalFileRepository.java
+++ b/modules/user/src/main/java/com/dewple/user/repository/PersonalFileRepository.java
@@ -1,0 +1,19 @@
+package com.dewple.user.repository;
+
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.user.entity.PersonalFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PersonalFileRepository extends JpaRepository<PersonalFile, Long> {
+
+    List<PersonalFile> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, BaseStatus status);
+
+    Optional<PersonalFile> findByIdAndUserId(Long id, Long userId);
+
+    @Query("SELECT COALESCE(SUM(f.fileSize), 0) FROM PersonalFile f WHERE f.user.id = :userId AND f.status = :status")
+    long sumFileSizeByUserIdAndStatus(Long userId, BaseStatus status);
+}

--- a/modules/user/src/main/java/com/dewple/user/repository/UserRepository.java
+++ b/modules/user/src/main/java/com/dewple/user/repository/UserRepository.java
@@ -3,9 +3,13 @@ package com.dewple.user.repository;
 import com.dewple.common.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    List<User> findByDeletedAtNotNullAndDeletedAtBefore(OffsetDateTime before);
 
     boolean existsByPhone(String phone);
 

--- a/modules/user/src/main/java/com/dewple/user/repository/UserRepository.java
+++ b/modules/user/src/main/java/com/dewple/user/repository/UserRepository.java
@@ -11,13 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUserId(String userId);
 
-    boolean existsByNickname(String nickname);
-
     boolean existsByEmail(String email);
 
     Optional<User> findByUserId(String userId);
-
-    boolean existsByNicknameAndIdNot(String nickname, Long id);
 
     boolean existsByEmailAndIdNot(String email, Long id);
 }

--- a/modules/user/src/main/java/com/dewple/user/repository/UserRepository.java
+++ b/modules/user/src/main/java/com/dewple/user/repository/UserRepository.java
@@ -15,5 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(String userId);
 
+    Optional<User> findByPhone(String phone);
+
     boolean existsByEmailAndIdNot(String email, Long id);
 }

--- a/modules/user/src/main/java/com/dewple/user/service/EditMyProfileParam.java
+++ b/modules/user/src/main/java/com/dewple/user/service/EditMyProfileParam.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record EditMyProfileParam(
         String nickname,
         String email,
+        String emailVerificationToken,
         LocalDate birthdate,
         Gender gender,
         University university,

--- a/modules/user/src/main/java/com/dewple/user/service/PersonalFileResult.java
+++ b/modules/user/src/main/java/com/dewple/user/service/PersonalFileResult.java
@@ -1,0 +1,23 @@
+package com.dewple.user.service;
+
+import com.dewple.user.entity.PersonalFile;
+
+import java.time.OffsetDateTime;
+
+public record PersonalFileResult(
+        Long id,
+        String originalName,
+        Long fileSize,
+        String contentType,
+        OffsetDateTime createdAt
+) {
+    public static PersonalFileResult from(PersonalFile file) {
+        return new PersonalFileResult(
+                file.getId(),
+                file.getOriginalName(),
+                file.getFileSize(),
+                file.getContentType(),
+                file.getCreatedAt()
+        );
+    }
+}

--- a/modules/user/src/main/java/com/dewple/user/service/PersonalFileService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/PersonalFileService.java
@@ -1,0 +1,94 @@
+package com.dewple.user.service;
+
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.BaseStatus;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.user.entity.PersonalFile;
+import com.dewple.user.exception.UserErrorCode;
+import com.dewple.user.port.FileStoragePort;
+import com.dewple.user.repository.PersonalFileRepository;
+import com.dewple.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonalFileService {
+
+    private static final long FREE_STORAGE_BYTES = 1L * 1024 * 1024 * 1024; // 1GB
+
+    private final PersonalFileRepository personalFileRepository;
+    private final UserRepository userRepository;
+    private final FileStoragePort fileStoragePort;
+
+    @Transactional
+    public PersonalFileResult uploadFile(Long userId, String originalName, long fileSize,
+                                         String contentType, InputStream inputStream) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        long currentUsage = personalFileRepository.sumFileSizeByUserIdAndStatus(userId, BaseStatus.ACTIVE);
+
+        // TODO: 초과 시 스토리지 추가 구매 기능 (과금 시스템 미구현)
+        if (currentUsage + fileSize > FREE_STORAGE_BYTES) {
+            throw new BusinessException(UserErrorCode.STORAGE_LIMIT_EXCEEDED);
+        }
+
+        String storedKey = String.format("personal/%d/%s_%s", userId, UUID.randomUUID(), originalName);
+        fileStoragePort.upload(storedKey, inputStream, fileSize, contentType);
+
+        PersonalFile file = PersonalFile.builder()
+                .user(user)
+                .originalName(originalName)
+                .storedKey(storedKey)
+                .fileSize(fileSize)
+                .contentType(contentType)
+                .build();
+
+        personalFileRepository.save(file);
+        log.info("개인 자료실 파일 업로드: userId={}, fileName={}, size={}", userId, originalName, fileSize);
+
+        return PersonalFileResult.from(file);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PersonalFileResult> getFiles(Long userId) {
+        return personalFileRepository.findByUserIdAndStatusOrderByCreatedAtDesc(userId, BaseStatus.ACTIVE)
+                .stream()
+                .map(PersonalFileResult::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public String getDownloadUrl(Long userId, Long fileId) {
+        PersonalFile file = personalFileRepository.findByIdAndUserId(fileId, userId)
+                .filter(f -> f.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.FILE_NOT_FOUND));
+
+        return fileStoragePort.generateDownloadUrl(file.getStoredKey());
+    }
+
+    @Transactional
+    public void deleteFile(Long userId, Long fileId) {
+        PersonalFile file = personalFileRepository.findByIdAndUserId(fileId, userId)
+                .filter(f -> f.getStatus() == BaseStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.FILE_NOT_FOUND));
+
+        file.inactivate();
+        fileStoragePort.delete(file.getStoredKey());
+        log.info("개인 자료실 파일 삭제: userId={}, fileId={}", userId, fileId);
+    }
+
+    @Transactional(readOnly = true)
+    public StorageUsageResult getStorageUsage(Long userId) {
+        long usedBytes = personalFileRepository.sumFileSizeByUserIdAndStatus(userId, BaseStatus.ACTIVE);
+        return new StorageUsageResult(usedBytes, FREE_STORAGE_BYTES);
+    }
+}

--- a/modules/user/src/main/java/com/dewple/user/service/PersonalFileService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/PersonalFileService.java
@@ -91,4 +91,17 @@ public class PersonalFileService {
         long usedBytes = personalFileRepository.sumFileSizeByUserIdAndStatus(userId, BaseStatus.ACTIVE);
         return new StorageUsageResult(usedBytes, FREE_STORAGE_BYTES);
     }
+
+    @Transactional
+    public void deleteAllByUserId(Long userId) {
+        List<PersonalFile> files = personalFileRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
+                userId, BaseStatus.ACTIVE);
+
+        for (PersonalFile file : files) {
+            fileStoragePort.delete(file.getStoredKey());
+        }
+
+        personalFileRepository.deleteAll(files);
+        log.info("개인 자료실 전체 삭제: userId={}, count={}", userId, files.size());
+    }
 }

--- a/modules/user/src/main/java/com/dewple/user/service/RandomNicknameGenerator.java
+++ b/modules/user/src/main/java/com/dewple/user/service/RandomNicknameGenerator.java
@@ -1,0 +1,47 @@
+package com.dewple.user.service;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.List;
+
+@Component
+public class RandomNicknameGenerator {
+
+    private static final List<String> SOURCES = List.of(
+            "하늘", "구름", "바람", "비", "눈", "별", "달", "해", "안개", "노을",
+            "무지개", "서리", "이슬", "폭풍", "천둥", "번개", "태양", "새벽", "황혼", "여명",
+            "호랑이", "사자", "여우", "곰", "늑대", "토끼", "고양이", "강아지", "용", "매",
+            "독수리", "부엉이", "까마귀", "돌고래", "고래", "펭귄", "다람쥐", "사슴", "두루미", "제비",
+            "나무", "꽃", "풀", "숲", "잎", "장미", "대나무", "소나무", "버드나무", "민들레",
+            "선인장", "연꽃", "벚꽃", "도토리", "씨앗", "이끼", "덩굴", "뿌리", "열매", "가시",
+            "레몬", "사과", "딸기", "포도", "복숭아", "수박", "귤", "체리", "망고", "호두",
+            "빵떡", "소금", "후추", "땅콩", "버터", "감자", "고구마", "오렌지", "자두",
+            "거울", "칼", "방패", "망치", "열쇠", "나침반", "모자", "안경", "깃털", "종이",
+            "가위", "바늘", "실", "북", "종", "촛불", "등불", "항아리", "부채", "주머니",
+            "봄", "여름", "가을", "겨울", "자정", "정오", "오후", "밤", "아침", "저녁",
+            "꿈", "기억", "희망", "지혜", "수수께끼", "비밀", "약속", "전설", "신화", "운명",
+            "그림자", "수정", "진주", "산호", "호박", "다이아", "루비", "옥", "강철",
+            "불꽃", "얼음", "파도", "소용돌이", "물결", "안식", "여행", "모험", "미로", "탑",
+            "성", "우주", "혜성", "유성", "행성", "성운", "은하", "오로라", "마법", "요정",
+            "유령", "산", "바다", "강", "호수", "섬", "언덕", "골짜기", "사막", "동굴",
+            "절벽", "오솔길", "들판", "늪", "빙하", "화산", "봉우리", "벼랑", "계곡", "갯벌", "모래"
+    );
+
+    private static final String SUFFIX_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
+    private static final int SUFFIX_LENGTH = 4;
+
+    private final SecureRandom random = new SecureRandom();
+
+    public String generate() {
+        String word1 = SOURCES.get(random.nextInt(SOURCES.size()));
+        String word2 = SOURCES.get(random.nextInt(SOURCES.size()));
+
+        StringBuilder suffix = new StringBuilder(SUFFIX_LENGTH);
+        for (int i = 0; i < SUFFIX_LENGTH; i++) {
+            suffix.append(SUFFIX_CHARS.charAt(random.nextInt(SUFFIX_CHARS.length())));
+        }
+
+        return word1 + word2 + suffix;
+    }
+}

--- a/modules/user/src/main/java/com/dewple/user/service/SignupParam.java
+++ b/modules/user/src/main/java/com/dewple/user/service/SignupParam.java
@@ -1,9 +1,14 @@
 package com.dewple.user.service;
 
+import com.dewple.common.enums.Gender;
+import java.time.LocalDate;
+
 public record SignupParam(
         String verificationToken,
         String name,
         String userId,
-        String password
+        String password,
+        LocalDate birthdate,
+        Gender gender
 ) {
 }

--- a/modules/user/src/main/java/com/dewple/user/service/SignupParam.java
+++ b/modules/user/src/main/java/com/dewple/user/service/SignupParam.java
@@ -9,6 +9,7 @@ public record SignupParam(
         String userId,
         String password,
         LocalDate birthdate,
-        Gender gender
+        Gender gender,
+        String nickname
 ) {
 }

--- a/modules/user/src/main/java/com/dewple/user/service/StorageUsageResult.java
+++ b/modules/user/src/main/java/com/dewple/user/service/StorageUsageResult.java
@@ -1,0 +1,7 @@
+package com.dewple.user.service;
+
+public record StorageUsageResult(
+        long usedBytes,
+        long totalBytes
+) {
+}

--- a/modules/user/src/main/java/com/dewple/user/service/UserHardDeleteService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserHardDeleteService.java
@@ -1,0 +1,46 @@
+package com.dewple.user.service;
+
+import com.dewple.common.entity.User;
+import com.dewple.user.port.WithdrawalClubPort;
+import com.dewple.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserHardDeleteService {
+
+    private final UserRepository userRepository;
+    private final WithdrawalClubPort withdrawalClubPort;
+
+    /**
+     * deletedAt으로부터 7일 경과한 유저를 하드삭제.
+     * app-worker 스케줄러에서 주기적으로 호출.
+     */
+    @Transactional
+    public int hardDeleteExpiredUsers() {
+        OffsetDateTime sevenDaysAgo = OffsetDateTime.now().minusDays(7);
+        List<User> expiredUsers = userRepository.findByDeletedAtNotNullAndDeletedAtBefore(sevenDaysAgo);
+
+        int count = 0;
+        for (User user : expiredUsers) {
+            withdrawalClubPort.removeFromAllClubs(user.getId());
+
+            // TODO: 게시물/댓글 유저명 → '(알 수 없음)' (게시물/댓글 엔티티 미구현)
+            // TODO: 지원서 응답 삭제
+            // 별점(StarRating)은 받은 유저 종속 데이터이므로 삭제하지 않음 (3-7d)
+
+            userRepository.delete(user);
+            log.info("회원 하드삭제 완료: userId={}", user.getUserId());
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/modules/user/src/main/java/com/dewple/user/service/UserProfileResult.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserProfileResult.java
@@ -1,5 +1,6 @@
 package com.dewple.user.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public record UserProfileResult(
@@ -7,6 +8,7 @@ public record UserProfileResult(
         String profileImg,
         String selfIntroduction,
         String mbti,
-        List<String> interests
+        List<String> interests,
+        BigDecimal star
 ) {
 }

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Slf4j
@@ -250,6 +251,32 @@ public class UserService {
         user.cancelDeletion();
 
         log.info("회원 탈퇴 취소: userId={}", user.getUserId());
+    }
+
+    /**
+     * deletedAt으로부터 7일 경과한 유저를 하드삭제.
+     * app-worker 스케줄러에서 주기적으로 호출.
+     */
+    @Transactional
+    public int hardDeleteExpiredUsers() {
+        OffsetDateTime sevenDaysAgo = OffsetDateTime.now().minusDays(7);
+        List<User> expiredUsers = userRepository.findByDeletedAtNotNullAndDeletedAtBefore(sevenDaysAgo);
+
+        int count = 0;
+        for (User user : expiredUsers) {
+            // 모든 동아리에서 탈퇴 처리
+            withdrawalClubPort.removeFromAllClubs(user.getId());
+
+            // TODO: 게시물/댓글 유저명 → '(알 수 없음)' (게시물/댓글 엔티티 미구현)
+            // TODO: 지원서 응답 삭제 (지원서 응답 삭제 로직 필요)
+            // 별점(StarRating)은 받은 유저 종속 데이터이므로 삭제하지 않음 (3-7d)
+
+            userRepository.delete(user);
+            log.info("회원 하드삭제 완료: userId={}", user.getUserId());
+            count++;
+        }
+
+        return count;
     }
 
     @Transactional

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -36,6 +36,7 @@ public class UserService {
     private final WithdrawalActivityPort withdrawalActivityPort;
     private final WithdrawalClubPort withdrawalClubPort;
     private final RandomNicknameGenerator randomNicknameGenerator;
+    private final PersonalFileService personalFileService;
 
     private static final String TEMP_PASSWORD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
     private static final int TEMP_PASSWORD_LENGTH = 12;
@@ -266,6 +267,9 @@ public class UserService {
         for (User user : expiredUsers) {
             // 모든 동아리에서 탈퇴 처리
             withdrawalClubPort.removeFromAllClubs(user.getId());
+
+            // 개인 자료실 파일 삭제 (S3 + DB)
+            personalFileService.deleteAllByUserId(user.getId());
 
             // TODO: 게시물/댓글 유저명 → '(알 수 없음)' (게시물/댓글 엔티티 미구현)
             // TODO: 지원서 응답 삭제 (지원서 응답 삭제 로직 필요)

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -45,6 +45,8 @@ public class UserService {
                 .password(passwordEncoderPort.encode(param.password()))
                 .name(param.name())
                 .phone(phone)
+                .birthdate(param.birthdate())
+                .gender(param.gender())
                 .build();
 
         userRepository.save(user);
@@ -53,10 +55,14 @@ public class UserService {
         return user;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public User login(LoginParam param) {
         User user = userRepository.findByUserId(param.userId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isInDeletionPeriod()) {
+            throw new BusinessException(UserErrorCode.USER_IN_DELETION);
+        }
 
         if (user.getStatus() != BaseStatus.ACTIVE) {
             throw new BusinessException(UserErrorCode.USER_INACTIVE);
@@ -66,6 +72,7 @@ public class UserService {
             throw new BusinessException(UserErrorCode.PASSWORD_MISMATCH);
         }
 
+        user.updateLastLoginAt();
         log.info("로그인 성공: userId={}", param.userId());
         return user;
     }
@@ -79,10 +86,6 @@ public class UserService {
     public User updateProfile(Long id, UpdateProfileParam param) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        if (param.nickname() != null && userRepository.existsByNickname(param.nickname())) {
-            throw new BusinessException(UserErrorCode.NICKNAME_ALREADY_EXISTS);
-        }
 
         if (param.email() != null && userRepository.existsByEmail(param.email())) {
             throw new BusinessException(UserErrorCode.EMAIL_ALREADY_EXISTS);
@@ -100,12 +103,19 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        if (param.nickname() != null && userRepository.existsByNicknameAndIdNot(param.nickname(), userId)) {
-            throw new BusinessException(UserErrorCode.NICKNAME_ALREADY_EXISTS);
-        }
-
         if (param.email() != null && userRepository.existsByEmailAndIdNot(param.email(), userId)) {
             throw new BusinessException(UserErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        if (param.email() != null && !param.email().equals(user.getEmail())) {
+            if (param.emailVerificationToken() == null) {
+                throw new BusinessException(UserErrorCode.EMAIL_VERIFICATION_REQUIRED);
+            }
+            String verifiedEmail = verificationService.validateVerificationToken(param.emailVerificationToken());
+            if (!verifiedEmail.equals(param.email())) {
+                throw new BusinessException(UserErrorCode.EMAIL_VERIFICATION_REQUIRED);
+            }
+            user.markEmailVerified();
         }
 
         user.editProfile(
@@ -143,6 +153,27 @@ public class UserService {
     }
 
     @Transactional
+    public void changeUserId(Long userId, String newUserId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.getUserId() == null) {
+            throw new BusinessException(UserErrorCode.KAKAO_ONLY_NO_USER_ID);
+        }
+
+        if (!user.canChangeUserId()) {
+            throw new BusinessException(UserErrorCode.USER_ID_CHANGE_COOLDOWN);
+        }
+
+        if (userRepository.existsByUserId(newUserId)) {
+            throw new BusinessException(UserErrorCode.USER_ID_ALREADY_EXISTS);
+        }
+
+        user.changeUserId(newUserId);
+        log.info("아이디 변경 완료: userId={}", newUserId);
+    }
+
+    @Transactional
     public void changePhone(Long userId, String verificationToken) {
         String newPhone = verificationService.validateVerificationToken(verificationToken);
 
@@ -170,8 +201,30 @@ public class UserService {
             throw new BusinessException(UserErrorCode.USER_INACTIVE);
         }
 
-        user.inactivate();
-        log.info("회원 탈퇴 완료: userId={}", user.getUserId());
+        user.markAsDeleted();
+
+        // TODO: 참여 중 모임의 참여 확정 즉시 취소 (선착순 모임이면 대기자 자동 승격)
+        // TODO: 모임장인 모임 처리 (모임관리자 있으면 승계, 없으면 모임 취소)
+        // TODO: 회장인 동아리 처리 (부회장→권한 수 많은 운영진→랜덤 부원 순 승계)
+
+        log.info("회원 탈퇴 요청 (소프트삭제): userId={}", user.getUserId());
+    }
+
+    @Transactional
+    public void cancelWithdrawal(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (!user.isInDeletionPeriod()) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        user.cancelDeletion();
+
+        // TODO: 탈퇴 취소 시 승계된 직위(회장직/모임장직)는 복원하지 않음
+        // TODO: 참여 확정도 미복원 (재신청 필요)
+
+        log.info("회원 탈퇴 취소: userId={}", user.getUserId());
     }
 
     @Transactional(readOnly = true)
@@ -196,7 +249,8 @@ public class UserService {
                 user.getProfileImg(),
                 user.getSelfIntroduction(),
                 mbti,
-                interests
+                interests,
+                user.getReputationScore()
         );
     }
 

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
     private final SmsVerificationPort smsVerificationPort;
     private final WithdrawalActivityPort withdrawalActivityPort;
     private final WithdrawalClubPort withdrawalClubPort;
+    private final RandomNicknameGenerator randomNicknameGenerator;
 
     private static final String TEMP_PASSWORD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
     private static final int TEMP_PASSWORD_LENGTH = 12;
@@ -51,10 +52,16 @@ public class UserService {
             throw new BusinessException(UserErrorCode.USER_ID_ALREADY_EXISTS);
         }
 
+        String nickname = param.nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = randomNicknameGenerator.generate();
+        }
+
         User user = User.builder()
                 .userId(param.userId())
                 .password(passwordEncoderPort.encode(param.password()))
                 .name(param.name())
+                .nickname(nickname)
                 .phone(phone)
                 .birthdate(param.birthdate())
                 .gender(param.gender())

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -7,6 +7,8 @@ import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.entity.UserCategory;
 import com.dewple.user.port.PasswordEncoderPort;
+import com.dewple.user.port.WithdrawalActivityPort;
+import com.dewple.user.port.WithdrawalClubPort;
 import com.dewple.user.repository.CategoryRepository;
 import com.dewple.user.repository.UserCategoryRepository;
 import com.dewple.user.repository.UserRepository;
@@ -27,6 +29,8 @@ public class UserService {
     private final CategoryRepository categoryRepository;
     private final VerificationService verificationService;
     private final PasswordEncoderPort passwordEncoderPort;
+    private final WithdrawalActivityPort withdrawalActivityPort;
+    private final WithdrawalClubPort withdrawalClubPort;
 
     @Transactional
     public User signup(SignupParam param) {
@@ -60,11 +64,8 @@ public class UserService {
         User user = userRepository.findByUserId(param.userId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        if (user.isInDeletionPeriod()) {
-            throw new BusinessException(UserErrorCode.USER_IN_DELETION);
-        }
-
-        if (user.getStatus() != BaseStatus.ACTIVE) {
+        // 소프트삭제 기간이 아닌 비활성 계정은 로그인 차단
+        if (user.getStatus() != BaseStatus.ACTIVE && !user.isInDeletionPeriod()) {
             throw new BusinessException(UserErrorCode.USER_INACTIVE);
         }
 
@@ -201,11 +202,23 @@ public class UserService {
             throw new BusinessException(UserErrorCode.USER_INACTIVE);
         }
 
+        // 1. deletedAt = now() 기록 + 소프트삭제
         user.markAsDeleted();
 
-        // TODO: 참여 중 모임의 참여 확정 즉시 취소 (선착순 모임이면 대기자 자동 승격)
-        // TODO: 모임장인 모임 처리 (모임관리자 있으면 승계, 없으면 모임 취소)
-        // TODO: 회장인 동아리 처리 (부회장→권한 수 많은 운영진→랜덤 부원 순 승계)
+        // 2. 참여 중 모임의 참여 확정 즉시 취소
+        withdrawalActivityPort.cancelConfirmedParticipations(userId);
+
+        // 3. 모임장인 모임 처리 (모임관리자 있으면 승계, 없으면 모임 취소)
+        withdrawalActivityPort.transferOrCancelLeaderActivities(userId);
+
+        // 4. 회장인 동아리 처리 (운영진 → 권한 수 많은 순 → 일반 부원 순 승계)
+        withdrawalClubPort.transferPresidentRoles(userId);
+
+        // TODO: 1주일 경과 후 하드삭제 스케줄러 (app-worker 모듈에서 구현 필요)
+        //   - 모든 동아리에서 탈퇴 처리 (이력에 탈퇴로 기록)
+        //   - 게시물/댓글 유지 (유저명 → '(알 수 없음)')
+        //   - 지원서 응답 삭제
+        //   - 다른 참여자에게 부여한 별점은 유지
 
         log.info("회원 탈퇴 요청 (소프트삭제): userId={}", user.getUserId());
     }
@@ -219,10 +232,8 @@ public class UserService {
             throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
         }
 
+        // 계정 복원 (단, 승계된 직위는 미복원)
         user.cancelDeletion();
-
-        // TODO: 탈퇴 취소 시 승계된 직위(회장직/모임장직)는 복원하지 않음
-        // TODO: 참여 확정도 미복원 (재신청 필요)
 
         log.info("회원 탈퇴 취소: userId={}", user.getUserId());
     }

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -254,35 +254,6 @@ public class UserService {
         log.info("회원 탈퇴 취소: userId={}", user.getUserId());
     }
 
-    /**
-     * deletedAt으로부터 7일 경과한 유저를 하드삭제.
-     * app-worker 스케줄러에서 주기적으로 호출.
-     */
-    @Transactional
-    public int hardDeleteExpiredUsers() {
-        OffsetDateTime sevenDaysAgo = OffsetDateTime.now().minusDays(7);
-        List<User> expiredUsers = userRepository.findByDeletedAtNotNullAndDeletedAtBefore(sevenDaysAgo);
-
-        int count = 0;
-        for (User user : expiredUsers) {
-            // 모든 동아리에서 탈퇴 처리
-            withdrawalClubPort.removeFromAllClubs(user.getId());
-
-            // 개인 자료실 파일 삭제 (S3 + DB)
-            personalFileService.deleteAllByUserId(user.getId());
-
-            // TODO: 게시물/댓글 유저명 → '(알 수 없음)' (게시물/댓글 엔티티 미구현)
-            // TODO: 지원서 응답 삭제 (지원서 응답 삭제 로직 필요)
-            // 별점(StarRating)은 받은 유저 종속 데이터이므로 삭제하지 않음 (3-7d)
-
-            userRepository.delete(user);
-            log.info("회원 하드삭제 완료: userId={}", user.getUserId());
-            count++;
-        }
-
-        return count;
-    }
-
     @Transactional
     public void resetPassword(String verificationToken) {
         String phone = verificationService.validateVerificationToken(verificationToken);

--- a/modules/user/src/main/java/com/dewple/user/service/UserService.java
+++ b/modules/user/src/main/java/com/dewple/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.dewple.common.exception.BusinessException;
 import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.entity.UserCategory;
 import com.dewple.user.port.PasswordEncoderPort;
+import com.dewple.user.port.SmsVerificationPort;
 import com.dewple.user.port.WithdrawalActivityPort;
 import com.dewple.user.port.WithdrawalClubPort;
 import com.dewple.user.repository.CategoryRepository;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
 import java.util.List;
 
 @Slf4j
@@ -29,8 +31,13 @@ public class UserService {
     private final CategoryRepository categoryRepository;
     private final VerificationService verificationService;
     private final PasswordEncoderPort passwordEncoderPort;
+    private final SmsVerificationPort smsVerificationPort;
     private final WithdrawalActivityPort withdrawalActivityPort;
     private final WithdrawalClubPort withdrawalClubPort;
+
+    private static final String TEMP_PASSWORD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+    private static final int TEMP_PASSWORD_LENGTH = 12;
+    private final SecureRandom secureRandom = new SecureRandom();
 
     @Transactional
     public User signup(SignupParam param) {
@@ -236,6 +243,51 @@ public class UserService {
         user.cancelDeletion();
 
         log.info("회원 탈퇴 취소: userId={}", user.getUserId());
+    }
+
+    @Transactional
+    public void resetPassword(String verificationToken) {
+        String phone = verificationService.validateVerificationToken(verificationToken);
+
+        User user = userRepository.findByPhone(phone)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND_BY_PHONE));
+
+        if (user.getStatus() != BaseStatus.ACTIVE) {
+            throw new BusinessException(UserErrorCode.USER_INACTIVE);
+        }
+
+        // 카카오 전용 계정 (자체 아이디가 없는 경우)이면 안내
+        if (user.getUserId() == null) {
+            throw new BusinessException(UserErrorCode.KAKAO_ONLY_NO_PASSWORD);
+        }
+
+        String temporaryPassword = generateTemporaryPassword();
+        user.changePassword(passwordEncoderPort.encode(temporaryPassword));
+
+        smsVerificationPort.sendTemporaryPassword(phone, temporaryPassword);
+        log.info("임시 비밀번호 발급 완료: phone={}", phone.substring(0, phone.length() - 4) + "****");
+    }
+
+    private String generateTemporaryPassword() {
+        StringBuilder sb = new StringBuilder(TEMP_PASSWORD_LENGTH);
+        // 최소 요건 보장: 대문자, 소문자, 숫자, 특수문자 각 1개
+        sb.append("ABCDEFGHIJKLMNOPQRSTUVWXYz".charAt(secureRandom.nextInt(26)));
+        sb.append("abcdefghijklmnopqrstuvwxyz".charAt(secureRandom.nextInt(26)));
+        sb.append("0123456789".charAt(secureRandom.nextInt(10)));
+        sb.append("!@#$%^&*".charAt(secureRandom.nextInt(8)));
+        // 나머지 랜덤 채우기
+        for (int i = 4; i < TEMP_PASSWORD_LENGTH; i++) {
+            sb.append(TEMP_PASSWORD_CHARS.charAt(secureRandom.nextInt(TEMP_PASSWORD_CHARS.length())));
+        }
+        // 셔플
+        char[] chars = sb.toString().toCharArray();
+        for (int i = chars.length - 1; i > 0; i--) {
+            int j = secureRandom.nextInt(i + 1);
+            char temp = chars[i];
+            chars[i] = chars[j];
+            chars[j] = temp;
+        }
+        return new String(chars);
     }
 
     @Transactional(readOnly = true)

--- a/modules/user/src/test/java/com/dewple/user/service/UserServiceTest.java
+++ b/modules/user/src/test/java/com/dewple/user/service/UserServiceTest.java
@@ -9,6 +9,8 @@ import com.dewple.common.exception.BusinessException;
 import com.dewple.user.entity.UserCategory;
 import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.port.PasswordEncoderPort;
+import com.dewple.user.port.WithdrawalActivityPort;
+import com.dewple.user.port.WithdrawalClubPort;
 import com.dewple.user.repository.CategoryRepository;
 import com.dewple.user.repository.UserCategoryRepository;
 import com.dewple.user.repository.UserRepository;
@@ -54,6 +56,12 @@ class UserServiceTest {
     @Mock
     private PasswordEncoderPort passwordEncoderPort;
 
+    @Mock
+    private WithdrawalActivityPort withdrawalActivityPort;
+
+    @Mock
+    private WithdrawalClubPort withdrawalClubPort;
+
     @InjectMocks
     private UserService userService;
 
@@ -78,7 +86,7 @@ class UserServiceTest {
             given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            User result = userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD));
+            User result = userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null));
 
             // then
             assertThat(result).isNotNull();
@@ -100,7 +108,7 @@ class UserServiceTest {
             given(userRepository.existsByPhone(TEST_PHONE)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD)))
+            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null)))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
@@ -117,7 +125,7 @@ class UserServiceTest {
             given(userRepository.existsByUserId(TEST_USER_ID)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD)))
+            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null)))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
@@ -133,7 +141,7 @@ class UserServiceTest {
                     .willThrow(new BusinessException(UserErrorCode.VERIFICATION_TOKEN_INVALID));
 
             // when & then
-            assertThatThrownBy(() -> userService.signup(new SignupParam("invalid-token", TEST_NAME, TEST_USER_ID, TEST_PASSWORD)))
+            assertThatThrownBy(() -> userService.signup(new SignupParam("invalid-token", TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null)))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
@@ -183,7 +191,6 @@ class UserServiceTest {
             // given
             User user = createUser();
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userRepository.existsByNickname("듀플러")).willReturn(false);
             given(userRepository.existsByEmail("test@example.com")).willReturn(false);
 
             // when
@@ -196,24 +203,6 @@ class UserServiceTest {
             assertThat(result.getEmail()).isEqualTo("test@example.com");
             assertThat(result.getBirthdate()).isEqualTo(LocalDate.of(2000, 1, 1));
             assertThat(result.getGender()).isEqualTo(Gender.MALE);
-        }
-
-        @Test
-        @DisplayName("실패: 이미 사용 중인 닉네임")
-        void failWithNicknameAlreadyExists() {
-            // given
-            User user = createUser();
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userRepository.existsByNickname("듀플러")).willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> userService.updateProfile(1L, new UpdateProfileParam(
-                    "듀플러", null, null, null, null, null, null)))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(e -> {
-                        BusinessException be = (BusinessException) e;
-                        assertThat(be.getErrorCode()).isEqualTo(UserErrorCode.NICKNAME_ALREADY_EXISTS);
-                    });
         }
 
         @Test
@@ -701,11 +690,10 @@ class UserServiceTest {
                     Gender.MALE, University.SEOUL_NATIONAL, false, "기존직장");
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userRepository.existsByNicknameAndIdNot("새닉네임", 1L)).willReturn(false);
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(Collections.emptyList());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    "새닉네임", null, null, null, null, null, null, null, null, null, null);
+                    "새닉네임", null, null, null, null, null, null, null, null, null, null, null);
 
             // when
             MyProfileResult result = userService.editMyProfile(1L, command);
@@ -724,12 +712,11 @@ class UserServiceTest {
             ReflectionTestUtils.setField(user, "id", 1L);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userRepository.existsByNicknameAndIdNot("새닉네임", 1L)).willReturn(false);
             given(userRepository.existsByEmailAndIdNot("new@example.com", 1L)).willReturn(false);
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(Collections.emptyList());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    "새닉네임", "new@example.com", null, null, null, null, null, null, null, Mbti.INTJ, null);
+                    "새닉네임", "new@example.com", null, null, null, null, null, null, null, null, Mbti.INTJ, null);
 
             // when
             MyProfileResult result = userService.editMyProfile(1L, command);
@@ -761,7 +748,7 @@ class UserServiceTest {
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(List.of(uc1, uc2));
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    null, null, null, null, null, null, null, null, null, null, List.of(1L, 2L));
+                    null, null, null, null, null, null, null, null, null, null, null, List.of(1L, 2L));
 
             // when
             MyProfileResult result = userService.editMyProfile(1L, command);
@@ -783,7 +770,7 @@ class UserServiceTest {
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(Collections.emptyList());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    null, null, null, null, null, null, null, null, null, null, List.of());
+                    null, null, null, null, null, null, null, null, null, null, null, List.of());
 
             // when
             MyProfileResult result = userService.editMyProfile(1L, command);
@@ -805,7 +792,7 @@ class UserServiceTest {
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(Collections.emptyList());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    null, null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
 
             // when
             userService.editMyProfile(1L, command);
@@ -823,11 +810,10 @@ class UserServiceTest {
             user.updateProfile("기존닉네임", null, null, null, null, null, null);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userRepository.existsByNicknameAndIdNot("기존닉네임", 1L)).willReturn(false);
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(Collections.emptyList());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    "기존닉네임", null, null, null, null, null, null, null, null, null, null);
+                    "기존닉네임", null, null, null, null, null, null, null, null, null, null, null);
 
             // when
             MyProfileResult result = userService.editMyProfile(1L, command);
@@ -843,7 +829,7 @@ class UserServiceTest {
             given(userRepository.findById(999L)).willReturn(Optional.empty());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    "닉네임", null, null, null, null, null, null, null, null, null, null);
+                    "닉네임", null, null, null, null, null, null, null, null, null, null, null);
 
             // when & then
             assertThatThrownBy(() -> userService.editMyProfile(999L, command))
@@ -851,28 +837,6 @@ class UserServiceTest {
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
                         assertThat(be.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
-                    });
-        }
-
-        @Test
-        @DisplayName("실패: 닉네임 중복")
-        void failWithNicknameAlreadyExists() {
-            // given
-            User user = createUser();
-            ReflectionTestUtils.setField(user, "id", 1L);
-
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userRepository.existsByNicknameAndIdNot("중복닉네임", 1L)).willReturn(true);
-
-            EditMyProfileParam command = new EditMyProfileParam(
-                    "중복닉네임", null, null, null, null, null, null, null, null, null, null);
-
-            // when & then
-            assertThatThrownBy(() -> userService.editMyProfile(1L, command))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(e -> {
-                        BusinessException be = (BusinessException) e;
-                        assertThat(be.getErrorCode()).isEqualTo(UserErrorCode.NICKNAME_ALREADY_EXISTS);
                     });
         }
 
@@ -887,7 +851,7 @@ class UserServiceTest {
             given(userRepository.existsByEmailAndIdNot("dup@example.com", 1L)).willReturn(true);
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    null, "dup@example.com", null, null, null, null, null, null, null, null, null);
+                    null, "dup@example.com", null, null, null, null, null, null, null, null, null, null);
 
             // when & then
             assertThatThrownBy(() -> userService.editMyProfile(1L, command))
@@ -910,7 +874,7 @@ class UserServiceTest {
                     List.of(Category.builder().name("개발").build()));
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    null, null, null, null, null, null, null, null, null, null, List.of(1L, 999L));
+                    null, null, null, null, null, null, null, null, null, null, null, List.of(1L, 999L));
 
             // when & then
             assertThatThrownBy(() -> userService.editMyProfile(1L, command))

--- a/modules/user/src/test/java/com/dewple/user/service/UserServiceTest.java
+++ b/modules/user/src/test/java/com/dewple/user/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import com.dewple.common.exception.BusinessException;
 import com.dewple.user.entity.UserCategory;
 import com.dewple.user.exception.UserErrorCode;
 import com.dewple.user.port.PasswordEncoderPort;
+import com.dewple.user.port.SmsVerificationPort;
 import com.dewple.user.port.WithdrawalActivityPort;
 import com.dewple.user.port.WithdrawalClubPort;
 import com.dewple.user.repository.CategoryRepository;
@@ -57,10 +58,16 @@ class UserServiceTest {
     private PasswordEncoderPort passwordEncoderPort;
 
     @Mock
+    private SmsVerificationPort smsVerificationPort;
+
+    @Mock
     private WithdrawalActivityPort withdrawalActivityPort;
 
     @Mock
     private WithdrawalClubPort withdrawalClubPort;
+
+    @Mock
+    private RandomNicknameGenerator randomNicknameGenerator;
 
     @InjectMocks
     private UserService userService;
@@ -86,7 +93,7 @@ class UserServiceTest {
             given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            User result = userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null));
+            User result = userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null, null));
 
             // then
             assertThat(result).isNotNull();
@@ -108,7 +115,7 @@ class UserServiceTest {
             given(userRepository.existsByPhone(TEST_PHONE)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null)))
+            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null, null)))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
@@ -125,7 +132,7 @@ class UserServiceTest {
             given(userRepository.existsByUserId(TEST_USER_ID)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null)))
+            assertThatThrownBy(() -> userService.signup(new SignupParam(TEST_TOKEN, TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null, null)))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
@@ -141,7 +148,7 @@ class UserServiceTest {
                     .willThrow(new BusinessException(UserErrorCode.VERIFICATION_TOKEN_INVALID));
 
             // when & then
-            assertThatThrownBy(() -> userService.signup(new SignupParam("invalid-token", TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null)))
+            assertThatThrownBy(() -> userService.signup(new SignupParam("invalid-token", TEST_NAME, TEST_USER_ID, TEST_PASSWORD, null, null, null)))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> {
                         BusinessException be = (BusinessException) e;
@@ -713,10 +720,11 @@ class UserServiceTest {
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(userRepository.existsByEmailAndIdNot("new@example.com", 1L)).willReturn(false);
+            given(verificationService.validateVerificationToken("email-token")).willReturn("new@example.com");
             given(userCategoryRepository.findByUserIdWithCategory(1L)).willReturn(Collections.emptyList());
 
             EditMyProfileParam command = new EditMyProfileParam(
-                    "새닉네임", "new@example.com", null, null, null, null, null, null, null, null, Mbti.INTJ, null);
+                    "새닉네임", "new@example.com", "email-token", null, null, null, null, null, null, null, Mbti.INTJ, null);
 
             // when
             MyProfileResult result = userService.editMyProfile(1L, command);


### PR DESCRIPTION
## 📝 요약

- resolved #33

## 🔖 변경 사항

### 회원 도메인

| 항목 | 내용 |
|------|------|
| 회원가입 | 필수값 추가 (birthdate, gender), 아이디 규칙 수정 (3~32자), 비밀번호 상한 32자 |
| 닉네임 | 중복 체크 제거 (명세서 기준 중복 허용), 미설정 시 랜덤 자동 생성 |
| 회원 탈퇴 | deletedAt 소프트삭제 + 7일 후 하드삭제 스케줄러, 모임장/회장 승계, 탈퇴 취소 |
| 프로필 | star값 응답 추가, 이메일 변경 시 인증 필수, 아이디 변경 7일 쿨다운 |
| 비밀번호 찾기 | 임시비밀번호 SMS 발송, 카카오 전용 계정 예외 처리 |
| 개인 자료실 | S3 기반 파일 업로드/다운로드/삭제 |
| 별점 시스템 | 모임 종료 후 7일 이내 상호 익명 평가 (0~5), No-show 지정, 평균 자동 갱신 |
| 모임 이력 | CONFIRMED 참여자 기준, CANCELLED 모임 제외 조회 |

### 모임 도메인

| 항목 | 내용 |
|------|------|
| 모임관리자 | 초대코드 기반 등록 (최대 50명), 자격 해제 시 참여 취소, LEADER/MANAGER/PARTICIPANT role |
| 선착순 대기열 | 즉시확정/대기등록, 취소 시 자동 승격, 종료 시 대기열 소멸, 본인인증 모임 선택 참여 |
| 모임 생애주기 | ActivityLifecycleStatus 추가 (RECRUITING/IN_PROGRESS/ENDED/CANCELLED/DELETED) |
| 자동/수동 취소 | 참여자 0명 자동 취소 (5분 주기), 모임장 수동 취소 |
| 종료 처리 | endAt 경과 시 ENDED 전환 (5분 주기), 7일 후 DELETED (1시간 주기) |
| 참여자 공지 | 공지 CRUD + 댓글 CRUD, 참여 확정자만 열람 |
| 모임 문의 | 익명/실명 문의, 답변 전 수정/삭제, 운영진 답변/삭제 |
| 모임 신고 | 카테고리 선택 + 스냅샷 자동 저장, 7일 중복 제한, 6개월 후 스냅샷 삭제 |
| 필수값 추가 | 비상연락처, 카테고리/지역 필수, 참여 취소 기한 체크, 모임장 동시 운영 10개 제한 |
| 관심 모임 | 최대 20개 제한 |

### 인프라

| 항목 | 내용 |
|------|------|
| app-worker 스케줄러 | 모임 자동취소/종료/삭제, 신고 스냅샷 정리, 유저 하드삭제 (ActivityLifecycleScheduler + UserHardDeleteScheduler) |
| worker 어댑터 | JpaConfig, WithdrawalClubAdapter 추가 (Port-Adapter 패턴 준수) |
| Flyway V5 | activity_notice, activity_notice_comment, activity_inquiry, activity_report, star_rating 테이블 + manager_invite_code,
lifecycle_status 컬럼 |


## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
