### PR TITLE
[Feat/#38] 동아리 회원 관리 API 개발

### DIFF
--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityInquiryController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityInquiryController.java
@@ -20,7 +20,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Activity Inquiry", description = "모임 문의 API")
+@Tag(name = "Activity - 문의", description = "모임 문의 API")
 @RestController
 @RequestMapping("/activities/{activityId}/inquiries")
 @RequiredArgsConstructor

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityNoticeController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityNoticeController.java
@@ -23,7 +23,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Activity Notice", description = "모임 참여자 공지 API")
+@Tag(name = "Activity - 공지", description = "모임 참여자 공지 API")
 @RestController
 @RequestMapping("/activities/{activityId}/notices")
 @RequiredArgsConstructor

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityReportController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/ActivityReportController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Activity Report", description = "모임 신고 API")
+@Tag(name = "Activity - 신고", description = "모임 신고 API")
 @RestController
 @RequestMapping("/activities/{activityId}/reports")
 @RequiredArgsConstructor

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/StarRatingController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/activity/controller/StarRatingController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Star Rating", description = "별점 평가 API")
+@Tag(name = "Activity - 별점", description = "별점 평가 API")
 @RestController
 @RequestMapping("/activities/{activityId}/ratings")
 @RequiredArgsConstructor

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubController.java
@@ -6,6 +6,7 @@ import com.dewple.app_api_auth.api.club.dto.CreateClubRequest;
 import com.dewple.app_api_auth.api.club.dto.CreateClubResponse;
 import com.dewple.app_api_auth.api.club.dto.GetClubDetailResponse;
 import com.dewple.app_api_auth.api.club.dto.GetClubListResponse;
+import com.dewple.app_api_auth.api.club.dto.GetClubMemberResponse;
 import com.dewple.app_api_auth.api.club.dto.UpdateClubRequest;
 import com.dewple.app_api_auth.api.club.dto.UpdateClubSettingsRequest;
 import com.dewple.app_api_auth.global.response.ApiResponse;
@@ -17,8 +18,10 @@ import com.dewple.club.service.ClubSummaryResult;
 import com.dewple.club.service.CreateClubParam;
 import com.dewple.club.service.CreateClubResult;
 import com.dewple.club.service.GetClubListParam;
+import com.dewple.club.service.ClubMemberResult;
 import com.dewple.club.service.UpdateClubParam;
 import com.dewple.club.service.UpdateClubSettingsParam;
+import com.dewple.common.enums.ActivityStatus;
 import com.dewple.common.enums.ActivityType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,6 +34,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Club", description = "동아리 API")
 @RestController
@@ -63,6 +68,20 @@ public class ClubController {
     public ApiResponse<GetClubDetailResponse> getClubDetail(@PathVariable Long clubId) {
         ClubDetailResult result = clubService.getClubDetail(clubId);
         return ApiResponse.ok(GetClubDetailResponse.from(result));
+    }
+
+    @Operation(summary = "동아리 회원 목록 조회", description = "동아리 회원 목록을 조회합니다. 동아리 멤버만 조회 가능하며, 상태별 필터링이 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping("/{clubId}/members")
+    public ApiResponse<List<GetClubMemberResponse>> getMembers(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @Parameter(description = "활동 상태 필터") @RequestParam(required = false) ActivityStatus activityStatus
+    ) {
+        List<GetClubMemberResponse> responses = clubService.getMembers(userId, clubId, activityStatus).stream()
+                .map(GetClubMemberResponse::from)
+                .toList();
+        return ApiResponse.ok(responses);
     }
 
     @Operation(summary = "동아리 생성", description = "동아리를 생성합니다. 생성자가 자동으로 회장이 됩니다. 회장 동시 운영 최대 5개.")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubController.java
@@ -117,6 +117,31 @@ public class ClubController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "회원 내보내기 신청", description = "회원 내보내기를 신청합니다. 회원관리(9번) 권한 보유자 전원 동의가 필요하며, 1명이면 즉시 내보내기됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{clubId}/members/{memberId}/kick")
+    public ApiResponse<Void> requestKick(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long memberId
+    ) {
+        clubService.requestKick(userId, clubId, memberId);
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "회원 내보내기 투표", description = "내보내기 투표에 동의 또는 거부합니다. 거부 시 투표가 즉시 종료됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{clubId}/members/{memberId}/kick/vote")
+    public ApiResponse<Void> voteKick(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long memberId,
+            @RequestParam boolean approved
+    ) {
+        clubService.voteKick(userId, clubId, memberId, approved);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "동아리 생성", description = "동아리를 생성합니다. 생성자가 자동으로 회장이 됩니다. 회장 동시 운영 최대 5개.")
     @SecurityRequirement(name = BEARER_AUTH)
     @PostMapping

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubController.java
@@ -7,6 +7,8 @@ import com.dewple.app_api_auth.api.club.dto.CreateClubResponse;
 import com.dewple.app_api_auth.api.club.dto.GetClubDetailResponse;
 import com.dewple.app_api_auth.api.club.dto.GetClubListResponse;
 import com.dewple.app_api_auth.api.club.dto.GetClubMemberResponse;
+import com.dewple.app_api_auth.api.club.dto.InviteGuestRequest;
+import com.dewple.app_api_auth.api.club.dto.PromoteToMemberRequest;
 import com.dewple.app_api_auth.api.club.dto.UpdateClubRequest;
 import com.dewple.app_api_auth.api.club.dto.UpdateClubSettingsRequest;
 import com.dewple.app_api_auth.global.response.ApiResponse;
@@ -19,6 +21,8 @@ import com.dewple.club.service.CreateClubParam;
 import com.dewple.club.service.CreateClubResult;
 import com.dewple.club.service.GetClubListParam;
 import com.dewple.club.service.ClubMemberResult;
+import com.dewple.club.service.InviteGuestParam;
+import com.dewple.club.service.PromoteToMemberParam;
 import com.dewple.club.service.UpdateClubParam;
 import com.dewple.club.service.UpdateClubSettingsParam;
 import com.dewple.common.enums.ActivityStatus;
@@ -82,6 +86,35 @@ public class ClubController {
                 .map(GetClubMemberResponse::from)
                 .toList();
         return ApiResponse.ok(responses);
+    }
+
+    @Operation(summary = "GUEST 초대", description = "외부인을 GUEST로 초대합니다. 모임 지정이 필수이며, 회원관리(9번) 권한이 필요합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/{clubId}/members/guest")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<GetClubMemberResponse> inviteGuest(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @Valid @RequestBody InviteGuestRequest request
+    ) {
+        InviteGuestParam param = new InviteGuestParam(request.userId(), request.activityIds());
+        ClubMemberResult result = clubService.inviteGuest(userId, clubId, param);
+        return ApiResponse.ok(GetClubMemberResponse.from(result));
+    }
+
+    @Operation(summary = "GUEST→MEMBER 승격", description = "GUEST를 정식 멤버로 승격합니다. 기수 지정 및 활동 기한 설정이 필수이며, 회원관리(9번) 권한이 필요합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{clubId}/members/{memberId}/promote")
+    public ApiResponse<Void> promoteToMember(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long memberId,
+            @Valid @RequestBody PromoteToMemberRequest request
+    ) {
+        PromoteToMemberParam param = new PromoteToMemberParam(
+                request.generationId(), request.activityEndDate());
+        clubService.promoteToMember(userId, clubId, memberId, param);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "동아리 생성", description = "동아리를 생성합니다. 생성자가 자동으로 회장이 됩니다. 회장 동시 운영 최대 5개.")

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
@@ -1,0 +1,55 @@
+package com.dewple.app_api_auth.api.club.controller;
+
+import static com.dewple.app_api_auth.global.config.SwaggerConfig.BEARER_AUTH;
+
+import com.dewple.app_api_auth.api.club.dto.ClubRoleResponse;
+import com.dewple.app_api_auth.api.club.dto.CreateClubRoleRequest;
+import com.dewple.app_api_auth.global.response.ApiResponse;
+import com.dewple.app_api_auth.global.security.CurrentUserId;
+import com.dewple.club.service.ClubRoleResult;
+import com.dewple.club.service.ClubRoleService;
+import com.dewple.club.service.CreateClubRoleParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Club Role", description = "동아리 역할 관리 API")
+@RestController
+@RequestMapping("/clubs/{clubId}/roles")
+@RequiredArgsConstructor
+public class ClubRoleController {
+
+    private final ClubRoleService clubRoleService;
+
+    @Operation(summary = "역할 생성", description = "커스텀 역할을 생성합니다. 이름 + 권한 조합 + 운영진 여부를 설정합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<ClubRoleResponse> createRole(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @Valid @RequestBody CreateClubRoleRequest request
+    ) {
+        CreateClubRoleParam param = new CreateClubRoleParam(
+                request.name(), request.permissions(), request.isStaff()
+        );
+        ClubRoleResult result = clubRoleService.createRole(userId, clubId, param);
+        return ApiResponse.ok(ClubRoleResponse.from(result));
+    }
+
+    @Operation(summary = "역할 목록 조회", description = "동아리의 기본 역할 및 커스텀 역할 목록을 조회합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @GetMapping
+    public ApiResponse<List<ClubRoleResponse>> getRoles(@PathVariable Long clubId) {
+        List<ClubRoleResponse> responses = clubRoleService.getRoles(clubId).stream()
+                .map(ClubRoleResponse::from)
+                .toList();
+        return ApiResponse.ok(responses);
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
@@ -73,6 +73,19 @@ public class ClubRoleController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "멤버에 역할 부여", description = "멤버에게 역할을 할당합니다. 회장 역할은 직접 할당할 수 없으며, 회장 위임 API를 사용해야 합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/members/{memberId}")
+    public ApiResponse<Void> assignRole(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long memberId,
+            @RequestParam Long roleId
+    ) {
+        clubRoleService.assignRole(userId, clubId, memberId, roleId);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "역할 목록 조회", description = "동아리의 기본 역할 및 커스텀 역할 목록을 조회합니다.")
     @SecurityRequirement(name = BEARER_AUTH)
     @GetMapping

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
@@ -8,7 +8,9 @@ import com.dewple.app_api_auth.global.response.ApiResponse;
 import com.dewple.app_api_auth.global.security.CurrentUserId;
 import com.dewple.club.service.ClubRoleResult;
 import com.dewple.club.service.ClubRoleService;
+import com.dewple.app_api_auth.api.club.dto.UpdateClubRoleRequest;
 import com.dewple.club.service.CreateClubRoleParam;
+import com.dewple.club.service.UpdateClubRoleParam;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,6 +42,22 @@ public class ClubRoleController {
                 request.name(), request.permissions(), request.isStaff()
         );
         ClubRoleResult result = clubRoleService.createRole(userId, clubId, param);
+        return ApiResponse.ok(ClubRoleResponse.from(result));
+    }
+
+    @Operation(summary = "역할 수정", description = "역할의 이름, 권한, 운영진 여부를 수정합니다. 회장 역할은 수정할 수 없습니다. 기본 역할은 회장만 수정 가능합니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PatchMapping("/{roleId}")
+    public ApiResponse<ClubRoleResponse> updateRole(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long roleId,
+            @Valid @RequestBody UpdateClubRoleRequest request
+    ) {
+        UpdateClubRoleParam param = new UpdateClubRoleParam(
+                request.name(), request.permissions(), request.isStaff()
+        );
+        ClubRoleResult result = clubRoleService.updateRole(userId, clubId, roleId, param);
         return ApiResponse.ok(ClubRoleResponse.from(result));
     }
 

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
@@ -61,6 +61,18 @@ public class ClubRoleController {
         return ApiResponse.ok(ClubRoleResponse.from(result));
     }
 
+    @Operation(summary = "역할 삭제", description = "커스텀 역할을 삭제합니다. 기본 역할은 삭제할 수 없습니다. 부여된 회원은 부원으로 자동 전환됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @DeleteMapping("/{roleId}")
+    public ApiResponse<Void> deleteRole(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long roleId
+    ) {
+        clubRoleService.deleteRole(userId, clubId, roleId);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "역할 목록 조회", description = "동아리의 기본 역할 및 커스텀 역할 목록을 조회합니다.")
     @SecurityRequirement(name = BEARER_AUTH)
     @GetMapping

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/controller/ClubRoleController.java
@@ -86,6 +86,18 @@ public class ClubRoleController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "회장 위임", description = "회장만 다른 멤버에게 회장을 위임할 수 있습니다. 기존 회장은 부원으로 전환됩니다.")
+    @SecurityRequirement(name = BEARER_AUTH)
+    @PostMapping("/delegate/{targetMemberId}")
+    public ApiResponse<Void> delegatePresident(
+            @CurrentUserId Long userId,
+            @PathVariable Long clubId,
+            @PathVariable Long targetMemberId
+    ) {
+        clubRoleService.delegatePresident(userId, clubId, targetMemberId);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "역할 목록 조회", description = "동아리의 기본 역할 및 커스텀 역할 목록을 조회합니다.")
     @SecurityRequirement(name = BEARER_AUTH)
     @GetMapping

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/ClubRoleResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/ClubRoleResponse.java
@@ -1,0 +1,27 @@
+package com.dewple.app_api_auth.api.club.dto;
+
+import com.dewple.club.service.ClubRoleResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "동아리 역할 응답")
+public record ClubRoleResponse(
+        @Schema(description = "역할 ID")
+        Long id,
+        @Schema(description = "역할 이름")
+        String name,
+        @Schema(description = "권한 목록")
+        List<String> permissions,
+        @Schema(description = "운영진 여부")
+        Boolean isStaff,
+        @Schema(description = "기본 역할 여부")
+        Boolean isDefault
+) {
+    public static ClubRoleResponse from(ClubRoleResult result) {
+        return new ClubRoleResponse(
+                result.id(), result.name(), result.permissions(),
+                result.isStaff(), result.isDefault()
+        );
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/CreateClubRoleRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/CreateClubRoleRequest.java
@@ -1,0 +1,25 @@
+package com.dewple.app_api_auth.api.club.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "동아리 역할 생성 요청")
+public record CreateClubRoleRequest(
+        @Schema(description = "역할 이름", example = "홍보담당")
+        @NotBlank(message = "역할 이름은 필수입니다.")
+        @Size(max = 50, message = "역할 이름은 50자 이내여야 합니다.")
+        String name,
+
+        @Schema(description = "권한 목록", example = "[\"MANAGE_NOTICE\", \"MANAGE_FEED\"]")
+        @NotNull(message = "권한 목록은 필수입니다.")
+        List<String> permissions,
+
+        @Schema(description = "운영진 여부", example = "true")
+        @NotNull(message = "운영진 여부는 필수입니다.")
+        Boolean isStaff
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/GetClubMemberResponse.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/GetClubMemberResponse.java
@@ -1,0 +1,36 @@
+package com.dewple.app_api_auth.api.club.dto;
+
+import com.dewple.club.service.ClubMemberResult;
+import com.dewple.common.enums.ActivityStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "동아리 멤버 응답")
+public record GetClubMemberResponse(
+        @Schema(description = "멤버 ID")
+        Long memberId,
+        @Schema(description = "유저 ID")
+        Long userId,
+        @Schema(description = "이름")
+        String name,
+        @Schema(description = "닉네임")
+        String nickname,
+        @Schema(description = "프로필 이미지")
+        String profileImg,
+        @Schema(description = "역할명")
+        String roleName,
+        @Schema(description = "활동 상태")
+        ActivityStatus activityStatus,
+        @Schema(description = "별점")
+        BigDecimal reputationScore
+) {
+    public static GetClubMemberResponse from(ClubMemberResult result) {
+        return new GetClubMemberResponse(
+                result.memberId(), result.userId(),
+                result.name(), result.nickname(), result.profileImg(),
+                result.roleName(), result.activityStatus(),
+                result.reputationScore()
+        );
+    }
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/InviteGuestRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/InviteGuestRequest.java
@@ -1,0 +1,20 @@
+package com.dewple.app_api_auth.api.club.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "GUEST 초대 요청")
+public record InviteGuestRequest(
+        @Schema(description = "초대할 유저 ID", example = "5")
+        @NotNull(message = "유저 ID는 필수입니다.")
+        Long userId,
+
+        @Schema(description = "연결할 모임 ID 목록", example = "[1, 2]")
+        @NotNull(message = "모임 ID는 필수입니다.")
+        @Size(min = 1, message = "모임은 최소 1개 지정해야 합니다.")
+        List<Long> activityIds
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/PromoteToMemberRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/PromoteToMemberRequest.java
@@ -1,0 +1,18 @@
+package com.dewple.app_api_auth.api.club.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+@Schema(description = "GUEST→MEMBER 승격 요청")
+public record PromoteToMemberRequest(
+        @Schema(description = "기수 ID", example = "1")
+        @NotNull(message = "기수 ID는 필수입니다.")
+        Long generationId,
+
+        @Schema(description = "활동 종료일", example = "2026-12-31")
+        @NotNull(message = "활동 기한은 필수입니다.")
+        LocalDate activityEndDate
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/UpdateClubRoleRequest.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/club/dto/UpdateClubRoleRequest.java
@@ -1,0 +1,25 @@
+package com.dewple.app_api_auth.api.club.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "동아리 역할 수정 요청")
+public record UpdateClubRoleRequest(
+        @Schema(description = "역할 이름", example = "홍보담당")
+        @NotBlank(message = "역할 이름은 필수입니다.")
+        @Size(max = 50, message = "역할 이름은 50자 이내여야 합니다.")
+        String name,
+
+        @Schema(description = "권한 목록", example = "[\"MANAGE_NOTICE\", \"MANAGE_FEED\"]")
+        @NotNull(message = "권한 목록은 필수입니다.")
+        List<String> permissions,
+
+        @Schema(description = "운영진 여부", example = "true")
+        @NotNull(message = "운영진 여부는 필수입니다.")
+        Boolean isStaff
+) {
+}

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/organization/controller/OrganizationRoleController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/organization/controller/OrganizationRoleController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Organization Role", description = "연합회 역할 관리 API")
+@Tag(name = "Organization - 역할", description = "연합회 역할 관리 API")
 @RestController
 @RequestMapping("/organizations/{organizationId}/roles")
 @RequiredArgsConstructor

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/recruitment/controller/ApplicationController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/recruitment/controller/ApplicationController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Application", description = "지원서 API")
+@Tag(name = "Recruitment - 지원서", description = "지원서 API")
 @RestController
 @RequiredArgsConstructor
 public class ApplicationController {

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/recruitment/controller/ApplicationManageController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/recruitment/controller/ApplicationManageController.java
@@ -23,7 +23,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Application Management", description = "운영진 지원서 관리 API")
+@Tag(name = "Recruitment - 지원서 관리", description = "운영진 지원서 관리 API")
 @RestController
 @RequiredArgsConstructor
 public class ApplicationManageController {

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/recruitment/controller/RecruitmentController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/recruitment/controller/RecruitmentController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Recruitment", description = "공고 API")
+@Tag(name = "Recruitment - 공고", description = "공고 API")
 @RestController
 @RequiredArgsConstructor
 public class RecruitmentController {

--- a/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/PersonalFileController.java
+++ b/apps/app-api-auth/src/main/java/com/dewple/app_api_auth/api/user/controller/PersonalFileController.java
@@ -22,7 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
-@Tag(name = "Personal File", description = "개인 자료실 API")
+@Tag(name = "User - 개인 자료실", description = "개인 자료실 API")
 @RestController
 @RequestMapping("/users/me/files")
 @RequiredArgsConstructor

--- a/apps/app-api-auth/src/main/resources/db/migration/V9__add_club_kick_vote.sql
+++ b/apps/app-api-auth/src/main/resources/db/migration/V9__add_club_kick_vote.sql
@@ -1,0 +1,12 @@
+-- V9: 동아리 회원 내보내기 투표
+
+CREATE TABLE IF NOT EXISTS club_kick_vote (
+    id BIGSERIAL PRIMARY KEY,
+    club_id BIGINT NOT NULL REFERENCES club(id),
+    target_member_id BIGINT NOT NULL REFERENCES club_member(id),
+    voter_id BIGINT NOT NULL REFERENCES users(id),
+    is_approved BOOLEAN,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubControllerTest.java
@@ -3,12 +3,14 @@ package com.dewple.app_api_auth.api.club.controller;
 import com.dewple.app_api_auth.global.config.SecurityConfig;
 import com.dewple.club.exception.ClubErrorCode;
 import com.dewple.club.service.ClubDetailResult;
+import com.dewple.club.service.ClubMemberResult;
 import com.dewple.club.service.ClubService;
 import com.dewple.club.service.ClubSummaryResult;
 import com.dewple.club.service.CreateClubResult;
 import com.dewple.club.service.GetClubListParam;
 import com.dewple.club.service.UpdateClubParam;
 import com.dewple.club.service.UpdateClubSettingsParam;
+import com.dewple.common.enums.ActivityStatus;
 import com.dewple.common.enums.ActivityType;
 import com.dewple.common.enums.Gender;
 import com.dewple.common.exception.BusinessException;
@@ -155,6 +157,52 @@ class ClubControllerTest {
             mockMvc.perform(get("/clubs/1"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(1000));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /clubs/{clubId}/members - 회원 목록 조회")
+    class GetMembers {
+
+        @Test
+        @DisplayName("성공: 전체 멤버 조회")
+        void success() throws Exception {
+            List<ClubMemberResult> results = List.of(
+                    new ClubMemberResult(50L, 1L, "홍길동", "길동이", null, "회장",
+                            ActivityStatus.ACTIVE, BigDecimal.valueOf(4.5)),
+                    new ClubMemberResult(51L, 2L, "김철수", "철수", "profile.jpg", "부원",
+                            ActivityStatus.ACTIVE, BigDecimal.valueOf(3.8))
+            );
+            given(clubService.getMembers(eq(1L), eq(100L), any())).willReturn(results);
+
+            mockMvc.perform(get("/clubs/100/members")
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.length()").value(2))
+                    .andExpect(jsonPath("$.result[0].roleName").value("회장"))
+                    .andExpect(jsonPath("$.result[0].reputationScore").value(4.5))
+                    .andExpect(jsonPath("$.result[1].nickname").value("철수"));
+        }
+
+        @Test
+        @DisplayName("성공: 상태별 필터 조회")
+        void successWithFilter() throws Exception {
+            given(clubService.getMembers(eq(1L), eq(100L), eq(ActivityStatus.GUEST)))
+                    .willReturn(List.of());
+
+            mockMvc.perform(get("/clubs/100/members")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .param("activityStatus", "GUEST"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result").isEmpty());
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없음")
+        void failNoAuth() throws Exception {
+            mockMvc.perform(get("/clubs/100/members"))
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
@@ -24,8 +24,11 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -161,6 +164,33 @@ class ClubRoleControllerTest {
                             .with(jwt().jwt(j -> j.subject("1")))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(json))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /clubs/{clubId}/roles/{roleId} - 역할 삭제")
+    class DeleteRole {
+
+        @Test
+        @DisplayName("성공: 커스텀 역할 삭제")
+        void success() throws Exception {
+            willDoNothing().given(clubRoleService).deleteRole(eq(1L), eq(100L), eq(10L));
+
+            mockMvc.perform(delete("/clubs/100/roles/10")
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 기본 역할 삭제 시도")
+        void failDefaultRole() throws Exception {
+            willThrow(new BusinessException(ClubErrorCode.ROLE_DEFAULT_NOT_DELETABLE))
+                    .given(clubRoleService).deleteRole(eq(1L), eq(100L), eq(1L));
+
+            mockMvc.perform(delete("/clubs/100/roles/1")
+                            .with(jwt().jwt(j -> j.subject("1"))))
                     .andExpect(status().isBadRequest());
         }
     }

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
@@ -1,0 +1,144 @@
+package com.dewple.app_api_auth.api.club.controller;
+
+import com.dewple.app_api_auth.global.config.SecurityConfig;
+import com.dewple.club.exception.ClubErrorCode;
+import com.dewple.club.service.ClubRoleResult;
+import com.dewple.club.service.ClubRoleService;
+import com.dewple.club.service.CreateClubRoleParam;
+import com.dewple.common.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ClubRoleController.class)
+@Import(SecurityConfig.class)
+class ClubRoleControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockitoBean private ClubRoleService clubRoleService;
+    @MockitoBean private JwtDecoder jwtDecoder;
+
+    @Nested
+    @DisplayName("POST /clubs/{clubId}/roles - 역할 생성")
+    class CreateRole {
+
+        @Test
+        @DisplayName("성공: 역할 생성")
+        void success() throws Exception {
+            ClubRoleResult result = new ClubRoleResult(
+                    10L, "홍보담당", List.of("MANAGE_NOTICE", "MANAGE_FEED"), true, false);
+            given(clubRoleService.createRole(eq(1L), eq(100L), any(CreateClubRoleParam.class)))
+                    .willReturn(result);
+
+            String json = objectMapper.writeValueAsString(java.util.Map.of(
+                    "name", "홍보담당",
+                    "permissions", List.of("MANAGE_NOTICE", "MANAGE_FEED"),
+                    "isStaff", true
+            ));
+
+            mockMvc.perform(post("/clubs/100/roles")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.id").value(10))
+                    .andExpect(jsonPath("$.result.name").value("홍보담당"))
+                    .andExpect(jsonPath("$.result.isStaff").value(true))
+                    .andExpect(jsonPath("$.result.isDefault").value(false));
+        }
+
+        @Test
+        @DisplayName("실패: 이름 누락")
+        void failNameBlank() throws Exception {
+            String json = objectMapper.writeValueAsString(java.util.Map.of(
+                    "name", "",
+                    "permissions", List.of(),
+                    "isStaff", false
+            ));
+
+            mockMvc.perform(post("/clubs/100/roles")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없음")
+        void failNoAuth() throws Exception {
+            String json = objectMapper.writeValueAsString(java.util.Map.of(
+                    "name", "역할",
+                    "permissions", List.of(),
+                    "isStaff", false
+            ));
+
+            mockMvc.perform(post("/clubs/100/roles")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: 권한 없는 유저")
+        void failForbidden() throws Exception {
+            given(clubRoleService.createRole(eq(999L), eq(100L), any(CreateClubRoleParam.class)))
+                    .willThrow(new BusinessException(ClubErrorCode.ROLE_MANAGE_FORBIDDEN));
+
+            String json = objectMapper.writeValueAsString(java.util.Map.of(
+                    "name", "역할",
+                    "permissions", List.of(),
+                    "isStaff", false
+            ));
+
+            mockMvc.perform(post("/clubs/100/roles")
+                            .with(jwt().jwt(j -> j.subject("999")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /clubs/{clubId}/roles - 역할 목록 조회")
+    class GetRoles {
+
+        @Test
+        @DisplayName("성공: 역할 목록 조회")
+        void success() throws Exception {
+            List<ClubRoleResult> results = List.of(
+                    new ClubRoleResult(1L, "회장", List.of("PROPOSE_ACTIVITY", "MANAGE_ACTIVITY"), true, true),
+                    new ClubRoleResult(10L, "홍보담당", List.of("MANAGE_NOTICE"), true, false)
+            );
+            given(clubRoleService.getRoles(eq(100L))).willReturn(results);
+
+            mockMvc.perform(get("/clubs/100/roles")
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.length()").value(2))
+                    .andExpect(jsonPath("$.result[0].name").value("회장"))
+                    .andExpect(jsonPath("$.result[0].isDefault").value(true))
+                    .andExpect(jsonPath("$.result[1].name").value("홍보담당"));
+        }
+    }
+}

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
@@ -234,6 +234,45 @@ class ClubRoleControllerTest {
     }
 
     @Nested
+    @DisplayName("POST /clubs/{clubId}/roles/delegate/{targetMemberId} - 회장 위임")
+    class DelegatePresident {
+
+        @Test
+        @DisplayName("성공: 회장 위임")
+        void success() throws Exception {
+            willDoNothing().given(clubRoleService)
+                    .delegatePresident(eq(1L), eq(100L), eq(60L));
+
+            mockMvc.perform(post("/clubs/100/roles/delegate/60")
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 회장이 아닌 유저")
+        void failNotPresident() throws Exception {
+            willThrow(new BusinessException(ClubErrorCode.DELEGATE_FORBIDDEN))
+                    .given(clubRoleService).delegatePresident(eq(999L), eq(100L), eq(60L));
+
+            mockMvc.perform(post("/clubs/100/roles/delegate/60")
+                            .with(jwt().jwt(j -> j.subject("999"))))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패: 자기 자신에게 위임")
+        void failSelf() throws Exception {
+            willThrow(new BusinessException(ClubErrorCode.DELEGATE_SELF))
+                    .given(clubRoleService).delegatePresident(eq(1L), eq(100L), eq(50L));
+
+            mockMvc.perform(post("/clubs/100/roles/delegate/50")
+                            .with(jwt().jwt(j -> j.subject("1"))))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
     @DisplayName("GET /clubs/{clubId}/roles - 역할 목록 조회")
     class GetRoles {
 

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
@@ -196,6 +196,44 @@ class ClubRoleControllerTest {
     }
 
     @Nested
+    @DisplayName("PATCH /clubs/{clubId}/roles/members/{memberId} - 멤버에 역할 부여")
+    class AssignRole {
+
+        @Test
+        @DisplayName("성공: 멤버에 역할 부여")
+        void success() throws Exception {
+            willDoNothing().given(clubRoleService)
+                    .assignRole(eq(1L), eq(100L), eq(60L), eq(10L));
+
+            mockMvc.perform(patch("/clubs/100/roles/members/60")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .param("roleId", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000));
+        }
+
+        @Test
+        @DisplayName("실패: 회장 역할 직접 할당")
+        void failPresidentRole() throws Exception {
+            willThrow(new BusinessException(ClubErrorCode.PRESIDENT_ROLE_NOT_ASSIGNABLE))
+                    .given(clubRoleService).assignRole(eq(1L), eq(100L), eq(60L), eq(1L));
+
+            mockMvc.perform(patch("/clubs/100/roles/members/60")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .param("roleId", "1"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없음")
+        void failNoAuth() throws Exception {
+            mockMvc.perform(patch("/clubs/100/roles/members/60")
+                            .param("roleId", "10"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
     @DisplayName("GET /clubs/{clubId}/roles - 역할 목록 조회")
     class GetRoles {
 

--- a/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
+++ b/apps/app-api-auth/src/test/java/com/dewple/app_api_auth/api/club/controller/ClubRoleControllerTest.java
@@ -5,6 +5,7 @@ import com.dewple.club.exception.ClubErrorCode;
 import com.dewple.club.service.ClubRoleResult;
 import com.dewple.club.service.ClubRoleService;
 import com.dewple.club.service.CreateClubRoleParam;
+import com.dewple.club.service.UpdateClubRoleParam;
 import com.dewple.common.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -115,6 +117,51 @@ class ClubRoleControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(json))
                     .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /clubs/{clubId}/roles/{roleId} - 역할 수정")
+    class UpdateRole {
+
+        @Test
+        @DisplayName("성공: 역할 수정")
+        void success() throws Exception {
+            ClubRoleResult result = new ClubRoleResult(
+                    10L, "수정된역할", List.of("MANAGE_CALENDAR"), false, false);
+            given(clubRoleService.updateRole(eq(1L), eq(100L), eq(10L), any(UpdateClubRoleParam.class)))
+                    .willReturn(result);
+
+            String json = objectMapper.writeValueAsString(java.util.Map.of(
+                    "name", "수정된역할",
+                    "permissions", List.of("MANAGE_CALENDAR"),
+                    "isStaff", false
+            ));
+
+            mockMvc.perform(patch("/clubs/100/roles/10")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1000))
+                    .andExpect(jsonPath("$.result.name").value("수정된역할"))
+                    .andExpect(jsonPath("$.result.permissions[0]").value("MANAGE_CALENDAR"));
+        }
+
+        @Test
+        @DisplayName("실패: 회장 역할 수정 시도")
+        void failPresidentRole() throws Exception {
+            given(clubRoleService.updateRole(eq(1L), eq(100L), eq(1L), any(UpdateClubRoleParam.class)))
+                    .willThrow(new BusinessException(ClubErrorCode.PRESIDENT_ROLE_NOT_MODIFIABLE));
+
+            String json = objectMapper.writeValueAsString(java.util.Map.of(
+                    "name", "변경", "permissions", List.of(), "isStaff", false));
+
+            mockMvc.perform(patch("/clubs/100/roles/1")
+                            .with(jwt().jwt(j -> j.subject("1")))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isBadRequest());
         }
     }
 

--- a/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ClubMemberGraduationScheduler.java
+++ b/apps/app-worker/src/main/java/com/dewple/app_worker/job/scheduler/ClubMemberGraduationScheduler.java
@@ -1,0 +1,28 @@
+package com.dewple.app_worker.job.scheduler;
+
+import com.dewple.club.service.ClubService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClubMemberGraduationScheduler {
+
+    private final ClubService clubService;
+
+    /**
+     * 매일 자정에 실행.
+     * 활동 종료일이 지난 ACTIVE 멤버를 자동으로 GRADUATED 처리.
+     * GUEST는 수료 대상에서 제외 (ACTIVE 상태만 조회).
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void graduateExpiredMembers() {
+        int graduated = clubService.processGraduation();
+        if (graduated > 0) {
+            log.info("동아리 멤버 자동 수료 처리 완료: {}명", graduated);
+        }
+    }
+}

--- a/modules/club/src/main/java/com/dewple/club/entity/ClubKickVote.java
+++ b/modules/club/src/main/java/com/dewple/club/entity/ClubKickVote.java
@@ -1,0 +1,48 @@
+package com.dewple.club.entity;
+
+import com.dewple.common.entity.BaseEntity;
+import com.dewple.common.entity.Club;
+import com.dewple.common.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "club_kick_vote")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubKickVote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_member_id", nullable = false)
+    private ClubMember targetMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "voter_id", nullable = false)
+    private User voter;
+
+    @Column(name = "is_approved")
+    private Boolean isApproved;
+
+    @Builder
+    public ClubKickVote(Club club, ClubMember targetMember, User voter, Boolean isApproved) {
+        this.club = club;
+        this.targetMember = targetMember;
+        this.voter = voter;
+        this.isApproved = isApproved;
+    }
+
+    public void approve() {
+        this.isApproved = true;
+    }
+}

--- a/modules/club/src/main/java/com/dewple/club/entity/ClubMember.java
+++ b/modules/club/src/main/java/com/dewple/club/entity/ClubMember.java
@@ -67,4 +67,12 @@ public class ClubMember extends BaseEntity {
     public void updateActivityStatus(ActivityStatus activityStatus) {
         this.activityStatus = activityStatus;
     }
+
+    public void setJoinGeneration(ClubGeneration joinGeneration) {
+        this.joinGeneration = joinGeneration;
+    }
+
+    public void setActivityEndDate(LocalDate activityEndDate) {
+        this.activityEndDate = activityEndDate;
+    }
 }

--- a/modules/club/src/main/java/com/dewple/club/entity/ClubRole.java
+++ b/modules/club/src/main/java/com/dewple/club/entity/ClubRole.java
@@ -46,6 +46,12 @@ public class ClubRole extends BaseEntity {
         this.isDefault = isDefault != null ? isDefault : false;
     }
 
+    public void update(String name, Long permissions, Boolean isStaff) {
+        this.name = name;
+        this.permissions = permissions;
+        this.isStaff = isStaff;
+    }
+
     // 특정 권한을 가지고 있는지 확인
     public boolean hasPermission(Permission permission) {
         return (this.permissions & permission.getValue()) != 0;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -26,6 +26,9 @@ public enum ClubErrorCode implements ErrorCode {
     DELETION_CANCEL_FORBIDDEN(6014, HttpStatus.FORBIDDEN, "회장만 삭제를 취소할 수 있습니다."),
     DELETION_SANCTION_NOT_CANCELABLE(6015, HttpStatus.BAD_REQUEST, "서비스 관리자의 제재에 의한 삭제는 취소할 수 없습니다."),
     DELETION_GRACE_PERIOD_EXPIRED(6016, HttpStatus.BAD_REQUEST, "유예 기간이 만료되어 취소할 수 없습니다."),
+    ROLE_NOT_FOUND(6020, HttpStatus.NOT_FOUND, "역할을 찾을 수 없습니다."),
+    ROLE_NAME_DUPLICATED(6021, HttpStatus.BAD_REQUEST, "이미 존재하는 역할 이름입니다."),
+    ROLE_MANAGE_FORBIDDEN(6022, HttpStatus.FORBIDDEN, "역할을 관리할 권한이 없습니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -32,6 +32,8 @@ public enum ClubErrorCode implements ErrorCode {
     PRESIDENT_ROLE_NOT_MODIFIABLE(6023, HttpStatus.BAD_REQUEST, "회장 역할의 권한은 불변입니다."),
     DEFAULT_ROLE_MODIFY_FORBIDDEN(6024, HttpStatus.FORBIDDEN, "기본 역할은 회장만 수정할 수 있습니다."),
     ROLE_DEFAULT_NOT_DELETABLE(6025, HttpStatus.BAD_REQUEST, "기본 역할은 삭제할 수 없습니다."),
+    PRESIDENT_ROLE_NOT_ASSIGNABLE(6026, HttpStatus.BAD_REQUEST, "회장 역할은 직접 할당할 수 없습니다. 회장 위임을 사용하세요."),
+    MEMBER_NOT_FOUND(6027, HttpStatus.NOT_FOUND, "동아리 멤버를 찾을 수 없습니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -36,6 +36,11 @@ public enum ClubErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(6027, HttpStatus.NOT_FOUND, "동아리 멤버를 찾을 수 없습니다."),
     DELEGATE_FORBIDDEN(6028, HttpStatus.FORBIDDEN, "회장만 회장 위임을 할 수 있습니다."),
     DELEGATE_SELF(6029, HttpStatus.BAD_REQUEST, "자기 자신에게 위임할 수 없습니다."),
+    ALREADY_CLUB_MEMBER(6030, HttpStatus.BAD_REQUEST, "이미 동아리 멤버입니다."),
+    ACTIVITY_ID_REQUIRED(6031, HttpStatus.BAD_REQUEST, "GUEST 초대 시 모임 지정은 필수입니다."),
+    NOT_GUEST_STATUS(6032, HttpStatus.BAD_REQUEST, "GUEST 상태의 멤버만 승격할 수 있습니다."),
+    ACTIVITY_END_DATE_REQUIRED(6033, HttpStatus.BAD_REQUEST, "활동 기한은 필수입니다."),
+    GENERATION_NOT_FOUND(6034, HttpStatus.NOT_FOUND, "기수를 찾을 수 없습니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -29,6 +29,8 @@ public enum ClubErrorCode implements ErrorCode {
     ROLE_NOT_FOUND(6020, HttpStatus.NOT_FOUND, "역할을 찾을 수 없습니다."),
     ROLE_NAME_DUPLICATED(6021, HttpStatus.BAD_REQUEST, "이미 존재하는 역할 이름입니다."),
     ROLE_MANAGE_FORBIDDEN(6022, HttpStatus.FORBIDDEN, "역할을 관리할 권한이 없습니다."),
+    PRESIDENT_ROLE_NOT_MODIFIABLE(6023, HttpStatus.BAD_REQUEST, "회장 역할의 권한은 불변입니다."),
+    DEFAULT_ROLE_MODIFY_FORBIDDEN(6024, HttpStatus.FORBIDDEN, "기본 역할은 회장만 수정할 수 있습니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -31,6 +31,7 @@ public enum ClubErrorCode implements ErrorCode {
     ROLE_MANAGE_FORBIDDEN(6022, HttpStatus.FORBIDDEN, "역할을 관리할 권한이 없습니다."),
     PRESIDENT_ROLE_NOT_MODIFIABLE(6023, HttpStatus.BAD_REQUEST, "회장 역할의 권한은 불변입니다."),
     DEFAULT_ROLE_MODIFY_FORBIDDEN(6024, HttpStatus.FORBIDDEN, "기본 역할은 회장만 수정할 수 있습니다."),
+    ROLE_DEFAULT_NOT_DELETABLE(6025, HttpStatus.BAD_REQUEST, "기본 역할은 삭제할 수 없습니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -41,6 +41,9 @@ public enum ClubErrorCode implements ErrorCode {
     NOT_GUEST_STATUS(6032, HttpStatus.BAD_REQUEST, "GUEST 상태의 멤버만 승격할 수 있습니다."),
     ACTIVITY_END_DATE_REQUIRED(6033, HttpStatus.BAD_REQUEST, "활동 기한은 필수입니다."),
     GENERATION_NOT_FOUND(6034, HttpStatus.NOT_FOUND, "기수를 찾을 수 없습니다."),
+    KICK_ALREADY_IN_PROGRESS(6040, HttpStatus.BAD_REQUEST, "이미 내보내기 투표가 진행 중입니다."),
+    KICK_VOTE_NOT_FOUND(6041, HttpStatus.NOT_FOUND, "투표 대상이 아닙니다."),
+    KICK_NOT_IN_PROGRESS(6042, HttpStatus.BAD_REQUEST, "내보내기 투표가 진행 중이 아닙니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
+++ b/modules/club/src/main/java/com/dewple/club/exception/ClubErrorCode.java
@@ -34,6 +34,8 @@ public enum ClubErrorCode implements ErrorCode {
     ROLE_DEFAULT_NOT_DELETABLE(6025, HttpStatus.BAD_REQUEST, "기본 역할은 삭제할 수 없습니다."),
     PRESIDENT_ROLE_NOT_ASSIGNABLE(6026, HttpStatus.BAD_REQUEST, "회장 역할은 직접 할당할 수 없습니다. 회장 위임을 사용하세요."),
     MEMBER_NOT_FOUND(6027, HttpStatus.NOT_FOUND, "동아리 멤버를 찾을 수 없습니다."),
+    DELEGATE_FORBIDDEN(6028, HttpStatus.FORBIDDEN, "회장만 회장 위임을 할 수 있습니다."),
+    DELEGATE_SELF(6029, HttpStatus.BAD_REQUEST, "자기 자신에게 위임할 수 없습니다."),
     ;
 
     private final int code;

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubKickVoteRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubKickVoteRepository.java
@@ -1,0 +1,19 @@
+package com.dewple.club.repository;
+
+import com.dewple.club.entity.ClubKickVote;
+import com.dewple.club.entity.ClubMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ClubKickVoteRepository extends JpaRepository<ClubKickVote, Long> {
+
+    List<ClubKickVote> findByTargetMember(ClubMember targetMember);
+
+    Optional<ClubKickVote> findByTargetMemberAndVoterId(ClubMember targetMember, Long voterId);
+
+    void deleteByTargetMember(ClubMember targetMember);
+
+    boolean existsByTargetMember(ClubMember targetMember);
+}

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
@@ -25,4 +25,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
             Long clubId, BaseStatus status, ActivityStatus activityStatus);
 
     List<ClubMember> findByRole(ClubRole role);
+
+    Optional<ClubMember> findByClubIdAndId(Long clubId, Long memberId);
 }

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
@@ -27,4 +27,8 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findByRole(ClubRole role);
 
     Optional<ClubMember> findByClubIdAndId(Long clubId, Long memberId);
+
+    List<ClubMember> findByClubIdAndActivityStatus(Long clubId, ActivityStatus activityStatus);
+
+    List<ClubMember> findByClubId(Long clubId);
 }

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
@@ -4,6 +4,8 @@ import com.dewple.club.entity.ClubMember;
 import com.dewple.club.entity.ClubRole;
 import com.dewple.common.enums.ActivityStatus;
 import com.dewple.common.enums.BaseStatus;
+
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -31,4 +33,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findByClubIdAndActivityStatus(Long clubId, ActivityStatus activityStatus);
 
     List<ClubMember> findByClubId(Long clubId);
+
+    List<ClubMember> findByActivityStatusAndActivityEndDateLessThanEqual(
+            ActivityStatus activityStatus, LocalDate date);
 }

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubMemberRepository.java
@@ -1,6 +1,7 @@
 package com.dewple.club.repository;
 
 import com.dewple.club.entity.ClubMember;
+import com.dewple.club.entity.ClubRole;
 import com.dewple.common.enums.ActivityStatus;
 import com.dewple.common.enums.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     List<ClubMember> findByClubIdAndStatusAndActivityStatus(
             Long clubId, BaseStatus status, ActivityStatus activityStatus);
+
+    List<ClubMember> findByRole(ClubRole role);
 }

--- a/modules/club/src/main/java/com/dewple/club/repository/ClubRoleRepository.java
+++ b/modules/club/src/main/java/com/dewple/club/repository/ClubRoleRepository.java
@@ -3,9 +3,14 @@ package com.dewple.club.repository;
 import com.dewple.club.entity.ClubRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ClubRoleRepository extends JpaRepository<ClubRole, Long> {
 
     Optional<ClubRole> findByClubIdAndName(Long clubId, String name);
+
+    List<ClubRole> findByClubId(Long clubId);
+
+    boolean existsByClubIdAndName(Long clubId, String name);
 }

--- a/modules/club/src/main/java/com/dewple/club/service/ClubMemberResult.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubMemberResult.java
@@ -1,0 +1,30 @@
+package com.dewple.club.service;
+
+import com.dewple.club.entity.ClubMember;
+import com.dewple.common.enums.ActivityStatus;
+
+import java.math.BigDecimal;
+
+public record ClubMemberResult(
+        Long memberId,
+        Long userId,
+        String name,
+        String nickname,
+        String profileImg,
+        String roleName,
+        ActivityStatus activityStatus,
+        BigDecimal reputationScore
+) {
+    public static ClubMemberResult from(ClubMember member) {
+        return new ClubMemberResult(
+                member.getId(),
+                member.getUser().getId(),
+                member.getUser().getName(),
+                member.getUser().getNickname(),
+                member.getUser().getProfileImg(),
+                member.getRole().getName(),
+                member.getActivityStatus(),
+                member.getUser().getReputationScore()
+        );
+    }
+}

--- a/modules/club/src/main/java/com/dewple/club/service/ClubRoleResult.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubRoleResult.java
@@ -1,0 +1,28 @@
+package com.dewple.club.service;
+
+import com.dewple.club.entity.ClubRole;
+import com.dewple.common.enums.Permission;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record ClubRoleResult(
+        Long id,
+        String name,
+        List<String> permissions,
+        Boolean isStaff,
+        Boolean isDefault
+) {
+    public static ClubRoleResult from(ClubRole role) {
+        List<String> permissionNames = new ArrayList<>();
+        for (Permission p : Permission.values()) {
+            if (role.hasPermission(p)) {
+                permissionNames.add(p.name());
+            }
+        }
+        return new ClubRoleResult(
+                role.getId(), role.getName(), permissionNames,
+                role.getIsStaff(), role.getIsDefault()
+        );
+    }
+}

--- a/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
@@ -132,6 +132,37 @@ public class ClubRoleService {
         log.info("동아리 멤버 역할 변경: clubId={}, memberId={}, roleId={}", clubId, memberId, roleId);
     }
 
+    @Transactional
+    public void delegatePresident(Long userId, Long clubId, Long targetMemberId) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        ClubMember currentPresident = clubMemberRepository.findByClubIdAndUserId(clubId, userId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.NOT_CLUB_MEMBER));
+
+        ClubRole currentRole = currentPresident.getRole();
+        if (!PRESIDENT_ROLE_NAME.equals(currentRole.getName()) || !currentRole.getIsDefault()) {
+            throw new BusinessException(ClubErrorCode.DELEGATE_FORBIDDEN);
+        }
+
+        ClubMember targetMember = clubMemberRepository.findByClubIdAndId(clubId, targetMemberId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.MEMBER_NOT_FOUND));
+
+        if (currentPresident.getId().equals(targetMember.getId())) {
+            throw new BusinessException(ClubErrorCode.DELEGATE_SELF);
+        }
+
+        ClubRole presidentRole = currentPresident.getRole();
+        ClubRole defaultMemberRole = clubRoleRepository.findByClubIdAndName(clubId, DEFAULT_MEMBER_ROLE_NAME)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.ROLE_NOT_FOUND));
+
+        targetMember.changeRole(presidentRole);
+        currentPresident.changeRole(defaultMemberRole);
+
+        log.info("동아리 회장 위임: clubId={}, from={}, to={}",
+                clubId, currentPresident.getId(), targetMemberId);
+    }
+
     @Transactional(readOnly = true)
     public List<ClubRoleResult> getRoles(Long clubId) {
         if (!clubRepository.existsById(clubId)) {

--- a/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
@@ -53,6 +53,36 @@ public class ClubRoleService {
         return ClubRoleResult.from(role);
     }
 
+    @Transactional
+    public ClubRoleResult updateRole(Long userId, Long clubId, Long roleId, UpdateClubRoleParam param) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        ClubRole role = clubRoleRepository.findById(roleId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.ROLE_NOT_FOUND));
+
+        if (PRESIDENT_ROLE_NAME.equals(role.getName()) && role.getIsDefault()) {
+            throw new BusinessException(ClubErrorCode.PRESIDENT_ROLE_NOT_MODIFIABLE);
+        }
+
+        if (role.getIsDefault()) {
+            validatePresident(clubId, userId);
+        } else {
+            validateRoleManagePermission(clubId, userId);
+        }
+
+        if (!role.getName().equals(param.name())
+                && clubRoleRepository.existsByClubIdAndName(clubId, param.name())) {
+            throw new BusinessException(ClubErrorCode.ROLE_NAME_DUPLICATED);
+        }
+
+        long permissionBits = convertPermissions(param.permissions());
+        role.update(param.name(), permissionBits, param.isStaff());
+
+        log.info("동아리 역할 수정: clubId={}, roleId={}", clubId, roleId);
+        return ClubRoleResult.from(role);
+    }
+
     @Transactional(readOnly = true)
     public List<ClubRoleResult> getRoles(Long clubId) {
         if (!clubRepository.existsById(clubId)) {
@@ -73,6 +103,16 @@ public class ClubRoleService {
 
         if (!isPresident && !role.hasPermission(Permission.MANAGE_MEMBER)) {
             throw new BusinessException(ClubErrorCode.ROLE_MANAGE_FORBIDDEN);
+        }
+    }
+
+    private void validatePresident(Long clubId, Long userId) {
+        ClubMember member = clubMemberRepository.findByClubIdAndUserId(clubId, userId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.NOT_CLUB_MEMBER));
+
+        ClubRole role = member.getRole();
+        if (!PRESIDENT_ROLE_NAME.equals(role.getName()) || !role.getIsDefault()) {
+            throw new BusinessException(ClubErrorCode.DEFAULT_ROLE_MODIFY_FORBIDDEN);
         }
     }
 

--- a/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
@@ -111,6 +111,27 @@ public class ClubRoleService {
                 clubId, roleId, membersWithRole.size());
     }
 
+    @Transactional
+    public void assignRole(Long userId, Long clubId, Long memberId, Long roleId) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        validateRoleManagePermission(clubId, userId);
+
+        ClubMember member = clubMemberRepository.findByClubIdAndId(clubId, memberId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.MEMBER_NOT_FOUND));
+
+        ClubRole role = clubRoleRepository.findById(roleId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.ROLE_NOT_FOUND));
+
+        if (PRESIDENT_ROLE_NAME.equals(role.getName()) && role.getIsDefault()) {
+            throw new BusinessException(ClubErrorCode.PRESIDENT_ROLE_NOT_ASSIGNABLE);
+        }
+
+        member.changeRole(role);
+        log.info("동아리 멤버 역할 변경: clubId={}, memberId={}, roleId={}", clubId, memberId, roleId);
+    }
+
     @Transactional(readOnly = true)
     public List<ClubRoleResult> getRoles(Long clubId) {
         if (!clubRepository.existsById(clubId)) {

--- a/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
@@ -26,6 +26,7 @@ public class ClubRoleService {
     private final ClubMemberRepository clubMemberRepository;
 
     private static final String PRESIDENT_ROLE_NAME = "회장";
+    private static final String DEFAULT_MEMBER_ROLE_NAME = "부원";
 
     @Transactional
     public ClubRoleResult createRole(Long userId, Long clubId, CreateClubRoleParam param) {
@@ -81,6 +82,33 @@ public class ClubRoleService {
 
         log.info("동아리 역할 수정: clubId={}, roleId={}", clubId, roleId);
         return ClubRoleResult.from(role);
+    }
+
+    @Transactional
+    public void deleteRole(Long userId, Long clubId, Long roleId) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        validateRoleManagePermission(clubId, userId);
+
+        ClubRole role = clubRoleRepository.findById(roleId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.ROLE_NOT_FOUND));
+
+        if (role.getIsDefault()) {
+            throw new BusinessException(ClubErrorCode.ROLE_DEFAULT_NOT_DELETABLE);
+        }
+
+        ClubRole defaultMemberRole = clubRoleRepository.findByClubIdAndName(clubId, DEFAULT_MEMBER_ROLE_NAME)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.ROLE_NOT_FOUND));
+
+        List<ClubMember> membersWithRole = clubMemberRepository.findByRole(role);
+        for (ClubMember member : membersWithRole) {
+            member.changeRole(defaultMemberRole);
+        }
+
+        clubRoleRepository.delete(role);
+        log.info("동아리 역할 삭제: clubId={}, roleId={}, 전환된 멤버 수={}",
+                clubId, roleId, membersWithRole.size());
     }
 
     @Transactional(readOnly = true)

--- a/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubRoleService.java
@@ -1,0 +1,89 @@
+package com.dewple.club.service;
+
+import com.dewple.club.entity.ClubMember;
+import com.dewple.club.entity.ClubRole;
+import com.dewple.club.exception.ClubErrorCode;
+import com.dewple.club.repository.ClubMemberRepository;
+import com.dewple.club.repository.ClubRoleRepository;
+import com.dewple.common.entity.Club;
+import com.dewple.common.enums.Permission;
+import com.dewple.common.exception.BusinessException;
+import com.dewple.club.repository.ClubRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClubRoleService {
+
+    private final ClubRepository clubRepository;
+    private final ClubRoleRepository clubRoleRepository;
+    private final ClubMemberRepository clubMemberRepository;
+
+    private static final String PRESIDENT_ROLE_NAME = "회장";
+
+    @Transactional
+    public ClubRoleResult createRole(Long userId, Long clubId, CreateClubRoleParam param) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        validateRoleManagePermission(clubId, userId);
+
+        if (clubRoleRepository.existsByClubIdAndName(clubId, param.name())) {
+            throw new BusinessException(ClubErrorCode.ROLE_NAME_DUPLICATED);
+        }
+
+        long permissionBits = convertPermissions(param.permissions());
+
+        ClubRole role = ClubRole.builder()
+                .club(club)
+                .name(param.name())
+                .permissions(permissionBits)
+                .isStaff(param.isStaff())
+                .isDefault(false)
+                .build();
+
+        clubRoleRepository.save(role);
+        log.info("동아리 역할 생성: clubId={}, roleId={}, name={}", clubId, role.getId(), param.name());
+        return ClubRoleResult.from(role);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ClubRoleResult> getRoles(Long clubId) {
+        if (!clubRepository.existsById(clubId)) {
+            throw new BusinessException(ClubErrorCode.CLUB_NOT_FOUND);
+        }
+
+        return clubRoleRepository.findByClubId(clubId).stream()
+                .map(ClubRoleResult::from)
+                .toList();
+    }
+
+    private void validateRoleManagePermission(Long clubId, Long userId) {
+        ClubMember member = clubMemberRepository.findByClubIdAndUserId(clubId, userId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.NOT_CLUB_MEMBER));
+
+        ClubRole role = member.getRole();
+        boolean isPresident = PRESIDENT_ROLE_NAME.equals(role.getName()) && role.getIsDefault();
+
+        if (!isPresident && !role.hasPermission(Permission.MANAGE_MEMBER)) {
+            throw new BusinessException(ClubErrorCode.ROLE_MANAGE_FORBIDDEN);
+        }
+    }
+
+    private long convertPermissions(List<String> permissionNames) {
+        if (permissionNames == null || permissionNames.isEmpty()) {
+            return 0L;
+        }
+        long bits = 0L;
+        for (String name : permissionNames) {
+            bits |= Permission.valueOf(name).getValue();
+        }
+        return bits;
+    }
+}

--- a/modules/club/src/main/java/com/dewple/club/service/ClubService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubService.java
@@ -42,6 +42,7 @@ public class ClubService {
     private final RegionRepository regionRepository;
     private final ClubRecruitmentPort clubRecruitmentPort;
     private final ClubDeletionVoteRepository clubDeletionVoteRepository;
+    private final ClubGenerationRepository clubGenerationRepository;
 
     private static final String PRESIDENT_ROLE_NAME = "회장";
     private static final int MAX_PRESIDENT_CLUBS = 5;
@@ -92,6 +93,71 @@ public class ClubService {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
         return ClubDetailResult.from(club);
+    }
+
+    @Transactional
+    public ClubMemberResult inviteGuest(Long userId, Long clubId, InviteGuestParam param) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        validateClubPermission(clubId, userId, Permission.MANAGE_MEMBER);
+
+        if (param.activityIds() == null || param.activityIds().isEmpty()) {
+            throw new BusinessException(ClubErrorCode.ACTIVITY_ID_REQUIRED);
+        }
+
+        if (clubMemberRepository.findByClubIdAndUserId(clubId, param.userId()).isPresent()) {
+            throw new BusinessException(ClubErrorCode.ALREADY_CLUB_MEMBER);
+        }
+
+        User guestUser = userRepository.findById(param.userId())
+                .orElseThrow(() -> new BusinessException(CommonErrorCode.USER_NOT_FOUND));
+
+        ClubRole defaultMemberRole = clubRoleRepository.findByClubIdAndName(clubId, "부원")
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.ROLE_NOT_FOUND));
+
+        ClubMember guest = ClubMember.builder()
+                .club(club)
+                .user(guestUser)
+                .role(defaultMemberRole)
+                .activityStatus(ActivityStatus.GUEST)
+                .build();
+        clubMemberRepository.save(guest);
+
+        // TODO: activityIds로 모임 연결 (Activity 도메인 통합 시 구현)
+        log.info("동아리 GUEST 초대: clubId={}, guestUserId={}, activityIds={}",
+                clubId, param.userId(), param.activityIds());
+
+        return ClubMemberResult.from(guest);
+    }
+
+    @Transactional
+    public void promoteToMember(Long userId, Long clubId, Long memberId, PromoteToMemberParam param) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        validateClubPermission(clubId, userId, Permission.MANAGE_MEMBER);
+
+        ClubMember member = clubMemberRepository.findByClubIdAndId(clubId, memberId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getActivityStatus() != ActivityStatus.GUEST) {
+            throw new BusinessException(ClubErrorCode.NOT_GUEST_STATUS);
+        }
+
+        if (param.activityEndDate() == null) {
+            throw new BusinessException(ClubErrorCode.ACTIVITY_END_DATE_REQUIRED);
+        }
+
+        ClubGeneration generation = clubGenerationRepository.findById(param.generationId())
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.GENERATION_NOT_FOUND));
+
+        member.updateActivityStatus(ActivityStatus.ACTIVE);
+        member.setJoinGeneration(generation);
+        member.setActivityEndDate(param.activityEndDate());
+
+        log.info("동아리 GUEST→MEMBER 승격: clubId={}, memberId={}, generationId={}",
+                clubId, memberId, param.generationId());
     }
 
     @Transactional(readOnly = true)

--- a/modules/club/src/main/java/com/dewple/club/service/ClubService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubService.java
@@ -43,6 +43,7 @@ public class ClubService {
     private final ClubRecruitmentPort clubRecruitmentPort;
     private final ClubDeletionVoteRepository clubDeletionVoteRepository;
     private final ClubGenerationRepository clubGenerationRepository;
+    private final ClubKickVoteRepository clubKickVoteRepository;
 
     private static final String PRESIDENT_ROLE_NAME = "회장";
     private static final int MAX_PRESIDENT_CLUBS = 5;
@@ -158,6 +159,82 @@ public class ClubService {
 
         log.info("동아리 GUEST→MEMBER 승격: clubId={}, memberId={}, generationId={}",
                 clubId, memberId, param.generationId());
+    }
+
+    @Transactional
+    public void requestKick(Long userId, Long clubId, Long targetMemberId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        validateClubPermission(clubId, userId, Permission.MANAGE_MEMBER);
+
+        ClubMember targetMember = clubMemberRepository.findByClubIdAndId(clubId, targetMemberId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.MEMBER_NOT_FOUND));
+
+        if (clubKickVoteRepository.existsByTargetMember(targetMember)) {
+            throw new BusinessException(ClubErrorCode.KICK_ALREADY_IN_PROGRESS);
+        }
+
+        List<ClubMember> permissionMembers = clubMemberRepository
+                .findByClubIdAndStatusAndActivityStatus(clubId, BaseStatus.ACTIVE, ActivityStatus.ACTIVE)
+                .stream()
+                .filter(m -> m.getRole().hasPermission(Permission.MANAGE_MEMBER))
+                .toList();
+
+        for (ClubMember voter : permissionMembers) {
+            boolean isRequester = voter.getUser().getId().equals(userId);
+            clubKickVoteRepository.save(
+                    ClubKickVote.builder()
+                            .club(club)
+                            .targetMember(targetMember)
+                            .voter(voter.getUser())
+                            .isApproved(isRequester ? true : null)
+                            .build()
+            );
+        }
+
+        if (permissionMembers.size() == 1) {
+            targetMember.updateActivityStatus(ActivityStatus.KICKEDOUT);
+            clubKickVoteRepository.deleteByTargetMember(targetMember);
+            log.info("동아리 회원 내보내기 즉시 승인 (권한자 1명): clubId={}, targetMemberId={}",
+                    clubId, targetMemberId);
+        } else {
+            log.info("동아리 회원 내보내기 투표 시작: clubId={}, targetMemberId={}, 투표 대상={}명",
+                    clubId, targetMemberId, permissionMembers.size());
+        }
+    }
+
+    @Transactional
+    public void voteKick(Long userId, Long clubId, Long targetMemberId, boolean approved) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        ClubMember targetMember = clubMemberRepository.findByClubIdAndId(clubId, targetMemberId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.MEMBER_NOT_FOUND));
+
+        if (!clubKickVoteRepository.existsByTargetMember(targetMember)) {
+            throw new BusinessException(ClubErrorCode.KICK_NOT_IN_PROGRESS);
+        }
+
+        ClubKickVote vote = clubKickVoteRepository.findByTargetMemberAndVoterId(targetMember, userId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.KICK_VOTE_NOT_FOUND));
+
+        if (!approved) {
+            clubKickVoteRepository.deleteByTargetMember(targetMember);
+            log.info("동아리 내보내기 투표 거부 → 종료: clubId={}, targetMemberId={}", clubId, targetMemberId);
+            return;
+        }
+
+        vote.approve();
+
+        List<ClubKickVote> allVotes = clubKickVoteRepository.findByTargetMember(targetMember);
+        boolean allApproved = allVotes.stream().allMatch(v -> Boolean.TRUE.equals(v.getIsApproved()));
+
+        if (allApproved) {
+            targetMember.updateActivityStatus(ActivityStatus.KICKEDOUT);
+            clubKickVoteRepository.deleteByTargetMember(targetMember);
+            log.info("동아리 내보내기 전원 동의 → 완료: clubId={}, targetMemberId={}", clubId, targetMemberId);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/modules/club/src/main/java/com/dewple/club/service/ClubService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubService.java
@@ -317,7 +317,17 @@ public class ClubService {
                 .isStaff(true).isDefault(true).build();
 
         ClubRole vicePresident = ClubRole.builder()
-                .club(club).name("부회장").permissions(0L)
+                .club(club).name("부회장")
+                .permissions(Permission.combine(
+                        Permission.PROPOSE_ACTIVITY, Permission.MANAGE_ACTIVITY,
+                        Permission.EDIT_INFO, Permission.NETWORK_CHAT,
+                        Permission.ANSWER_INQUIRY, Permission.MANAGE_RECRUITMENT,
+                        Permission.DECIDE_ADMISSION, Permission.VIEW_APPLICATION,
+                        Permission.MANAGE_MEMBER, Permission.MANAGE_FEDERATION,
+                        Permission.MANAGE_NOTICE, Permission.MANAGE_FEED,
+                        Permission.MANAGE_ATTENDANCE, Permission.MANAGE_CALENDAR,
+                        Permission.MANAGE_STORAGE
+                ))
                 .isStaff(true).isDefault(true).build();
 
         ClubRole hr = ClubRole.builder()

--- a/modules/club/src/main/java/com/dewple/club/service/ClubService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -419,6 +420,22 @@ public class ClubService {
         club.cancelDeletion();
         clubDeletionVoteRepository.deleteByClubId(clubId);
         log.info("동아리 삭제 취소: clubId={}, userId={}", clubId, userId);
+    }
+
+    @Transactional
+    public int processGraduation() {
+        LocalDate today = LocalDate.now();
+        List<ClubMember> targets = clubMemberRepository
+                .findByActivityStatusAndActivityEndDateLessThanEqual(ActivityStatus.ACTIVE, today);
+
+        for (ClubMember member : targets) {
+            member.updateActivityStatus(ActivityStatus.GRADUATED);
+        }
+
+        if (!targets.isEmpty()) {
+            log.info("동아리 자동 수료 처리 완료: {}명", targets.size());
+        }
+        return targets.size();
     }
 
     private void validateClubPermission(Long clubId, Long userId, Permission permission) {

--- a/modules/club/src/main/java/com/dewple/club/service/ClubService.java
+++ b/modules/club/src/main/java/com/dewple/club/service/ClubService.java
@@ -94,6 +94,26 @@ public class ClubService {
         return ClubDetailResult.from(club);
     }
 
+    @Transactional(readOnly = true)
+    public List<ClubMemberResult> getMembers(Long userId, Long clubId, ActivityStatus activityStatus) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        clubMemberRepository.findByClubIdAndUserId(clubId, userId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.NOT_CLUB_MEMBER));
+
+        List<ClubMember> members;
+        if (activityStatus != null) {
+            members = clubMemberRepository.findByClubIdAndActivityStatus(clubId, activityStatus);
+        } else {
+            members = clubMemberRepository.findByClubId(clubId);
+        }
+
+        return members.stream()
+                .map(ClubMemberResult::from)
+                .toList();
+    }
+
     @Transactional
     public void updateClub(Long userId, Long clubId, UpdateClubParam param) {
         Club club = clubRepository.findById(clubId)

--- a/modules/club/src/main/java/com/dewple/club/service/CreateClubRoleParam.java
+++ b/modules/club/src/main/java/com/dewple/club/service/CreateClubRoleParam.java
@@ -1,0 +1,10 @@
+package com.dewple.club.service;
+
+import java.util.List;
+
+public record CreateClubRoleParam(
+        String name,
+        List<String> permissions,
+        Boolean isStaff
+) {
+}

--- a/modules/club/src/main/java/com/dewple/club/service/InviteGuestParam.java
+++ b/modules/club/src/main/java/com/dewple/club/service/InviteGuestParam.java
@@ -1,0 +1,9 @@
+package com.dewple.club.service;
+
+import java.util.List;
+
+public record InviteGuestParam(
+        Long userId,
+        List<Long> activityIds
+) {
+}

--- a/modules/club/src/main/java/com/dewple/club/service/PromoteToMemberParam.java
+++ b/modules/club/src/main/java/com/dewple/club/service/PromoteToMemberParam.java
@@ -1,0 +1,9 @@
+package com.dewple.club.service;
+
+import java.time.LocalDate;
+
+public record PromoteToMemberParam(
+        Long generationId,
+        LocalDate activityEndDate
+) {
+}

--- a/modules/club/src/main/java/com/dewple/club/service/UpdateClubRoleParam.java
+++ b/modules/club/src/main/java/com/dewple/club/service/UpdateClubRoleParam.java
@@ -1,0 +1,10 @@
+package com.dewple.club.service;
+
+import java.util.List;
+
+public record UpdateClubRoleParam(
+        String name,
+        List<String> permissions,
+        Boolean isStaff
+) {
+}

--- a/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
@@ -478,6 +478,100 @@ class ClubRoleServiceTest {
     }
 
     @Nested
+    @DisplayName("delegatePresident - 회장 위임")
+    class DelegatePresident {
+
+        @Test
+        @DisplayName("성공: 회장 위임")
+        void success() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+
+            ClubMember currentPresident = createPresidentMember(club);
+            ClubMember target = ClubMember.builder()
+                    .club(club).user(createUser(2L)).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(target, "id", 60L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                    .willReturn(Optional.of(currentPresident));
+            given(clubMemberRepository.findByClubIdAndId(CLUB_ID, 60L))
+                    .willReturn(Optional.of(target));
+            given(clubRoleRepository.findByClubIdAndName(CLUB_ID, "부원"))
+                    .willReturn(Optional.of(memberRole));
+
+            clubRoleService.delegatePresident(USER_ID, CLUB_ID, 60L);
+
+            assertThat(target.getRole().getName()).isEqualTo("회장");
+            assertThat(currentPresident.getRole().getName()).isEqualTo("부원");
+        }
+
+        @Test
+        @DisplayName("실패: 회장이 아닌 유저의 위임 시도")
+        void failNotPresident() {
+            Club club = createClub();
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            ClubMember member = ClubMember.builder()
+                    .club(club).user(createUser(USER_ID)).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(member, "id", 51L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                    .willReturn(Optional.of(member));
+
+            assertThatThrownBy(() -> clubRoleService.delegatePresident(USER_ID, CLUB_ID, 60L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.DELEGATE_FORBIDDEN));
+        }
+
+        @Test
+        @DisplayName("실패: 자기 자신에게 위임")
+        void failDelegateSelf() {
+            Club club = createClub();
+            ClubMember currentPresident = createPresidentMember(club);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                    .willReturn(Optional.of(currentPresident));
+            given(clubMemberRepository.findByClubIdAndId(CLUB_ID, 50L))
+                    .willReturn(Optional.of(currentPresident));
+
+            assertThatThrownBy(() -> clubRoleService.delegatePresident(USER_ID, CLUB_ID, 50L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.DELEGATE_SELF));
+        }
+
+        @Test
+        @DisplayName("실패: 대상 멤버 없음")
+        void failTargetNotFound() {
+            Club club = createClub();
+            ClubMember currentPresident = createPresidentMember(club);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                    .willReturn(Optional.of(currentPresident));
+            given(clubMemberRepository.findByClubIdAndId(CLUB_ID, 999L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubRoleService.delegatePresident(USER_ID, CLUB_ID, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.MEMBER_NOT_FOUND));
+        }
+    }
+
+    @Nested
     @DisplayName("getRoles - 역할 목록 조회")
     class GetRoles {
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class ClubRoleServiceTest {
@@ -321,6 +322,82 @@ class ClubRoleServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ClubErrorCode.DEFAULT_ROLE_MODIFY_FORBIDDEN));
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRole - 역할 삭제")
+    class DeleteRole {
+
+        private ClubRole createCustomRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("홍보담당")
+                    .permissions(Permission.combine(Permission.MANAGE_NOTICE))
+                    .isStaff(true).isDefault(false).build();
+            ReflectionTestUtils.setField(role, "id", 10L);
+            return role;
+        }
+
+        private ClubRole createDefaultMemberRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(role, "id", 5L);
+            return role;
+        }
+
+        @Test
+        @DisplayName("성공: 커스텀 역할 삭제 + 멤버 부원 전환")
+        void successWithMemberConversion() {
+            Club club = createClub();
+            ClubRole customRole = createCustomRole(club);
+            ClubRole memberRole = createDefaultMemberRole(club);
+            User otherUser = createUser(2L);
+            ClubMember member1 = ClubMember.builder()
+                    .club(club).user(otherUser).role(customRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(member1, "id", 60L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.findById(10L)).willReturn(Optional.of(customRole));
+            given(clubRoleRepository.findByClubIdAndName(CLUB_ID, "부원"))
+                    .willReturn(Optional.of(memberRole));
+            given(clubMemberRepository.findByRole(customRole)).willReturn(List.of(member1));
+
+            clubRoleService.deleteRole(USER_ID, CLUB_ID, 10L);
+
+            assertThat(member1.getRole().getName()).isEqualTo("부원");
+            then(clubRoleRepository).should().delete(customRole);
+        }
+
+        @Test
+        @DisplayName("실패: 기본 역할 삭제 시도")
+        void failDefaultRole() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.findById(1L)).willReturn(Optional.of(presidentRole));
+
+            assertThatThrownBy(() -> clubRoleService.deleteRole(USER_ID, CLUB_ID, 1L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ROLE_DEFAULT_NOT_DELETABLE));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 역할")
+        void failNotFound() {
+            Club club = createClub();
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubRoleService.deleteRole(USER_ID, CLUB_ID, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ROLE_NOT_FOUND));
         }
     }
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
@@ -402,6 +402,82 @@ class ClubRoleServiceTest {
     }
 
     @Nested
+    @DisplayName("assignRole - 멤버에 역할 부여")
+    class AssignRole {
+
+        @Test
+        @DisplayName("성공: 멤버에 커스텀 역할 부여")
+        void success() {
+            Club club = createClub();
+            ClubRole customRole = ClubRole.builder()
+                    .club(club).name("홍보담당")
+                    .permissions(Permission.combine(Permission.MANAGE_NOTICE))
+                    .isStaff(true).isDefault(false).build();
+            ReflectionTestUtils.setField(customRole, "id", 10L);
+
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            ClubMember target = ClubMember.builder()
+                    .club(club).user(createUser(2L)).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(target, "id", 60L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubMemberRepository.findByClubIdAndId(CLUB_ID, 60L))
+                    .willReturn(Optional.of(target));
+            given(clubRoleRepository.findById(10L)).willReturn(Optional.of(customRole));
+
+            clubRoleService.assignRole(USER_ID, CLUB_ID, 60L, 10L);
+
+            assertThat(target.getRole().getName()).isEqualTo("홍보담당");
+        }
+
+        @Test
+        @DisplayName("실패: 회장 역할 직접 할당 시도")
+        void failAssignPresident() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            ClubMember target = ClubMember.builder()
+                    .club(club).user(createUser(2L)).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(target, "id", 60L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubMemberRepository.findByClubIdAndId(CLUB_ID, 60L))
+                    .willReturn(Optional.of(target));
+            given(clubRoleRepository.findById(1L)).willReturn(Optional.of(presidentRole));
+
+            assertThatThrownBy(() -> clubRoleService.assignRole(USER_ID, CLUB_ID, 60L, 1L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.PRESIDENT_ROLE_NOT_ASSIGNABLE));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 멤버")
+        void failMemberNotFound() {
+            Club club = createClub();
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubMemberRepository.findByClubIdAndId(CLUB_ID, 999L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubRoleService.assignRole(USER_ID, CLUB_ID, 999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.MEMBER_NOT_FOUND));
+        }
+    }
+
+    @Nested
     @DisplayName("getRoles - 역할 목록 조회")
     class GetRoles {
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
@@ -1,0 +1,242 @@
+package com.dewple.club.service;
+
+import com.dewple.club.entity.ClubMember;
+import com.dewple.club.entity.ClubRole;
+import com.dewple.club.exception.ClubErrorCode;
+import com.dewple.club.repository.ClubMemberRepository;
+import com.dewple.club.repository.ClubRepository;
+import com.dewple.club.repository.ClubRoleRepository;
+import com.dewple.common.entity.Club;
+import com.dewple.common.entity.User;
+import com.dewple.common.enums.ActivityStatus;
+import com.dewple.common.enums.ActivityType;
+import com.dewple.common.enums.Permission;
+import com.dewple.common.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ClubRoleServiceTest {
+
+    @Mock private ClubRepository clubRepository;
+    @Mock private ClubRoleRepository clubRoleRepository;
+    @Mock private ClubMemberRepository clubMemberRepository;
+
+    @InjectMocks
+    private ClubRoleService clubRoleService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long CLUB_ID = 100L;
+
+    private User createUser(Long userId) {
+        User user = User.builder().userId("user" + userId).name("유저" + userId).phone("010").build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+
+    private Club createClub() {
+        Club club = Club.builder()
+                .creator(createUser(USER_ID)).name("코딩 동아리").activityType(ActivityType.BOTH)
+                .isVerificationRequired(false).build();
+        ReflectionTestUtils.setField(club, "id", CLUB_ID);
+        return club;
+    }
+
+    private ClubRole createPresidentRole(Club club) {
+        ClubRole role = ClubRole.builder()
+                .club(club).name("회장").permissions(Permission.all())
+                .isStaff(true).isDefault(true).build();
+        ReflectionTestUtils.setField(role, "id", 1L);
+        return role;
+    }
+
+    private ClubMember createPresidentMember(Club club) {
+        ClubRole role = createPresidentRole(club);
+        ClubMember member = ClubMember.builder()
+                .club(club).user(club.getCreator()).role(role)
+                .activityStatus(ActivityStatus.ACTIVE).build();
+        ReflectionTestUtils.setField(member, "id", 50L);
+        return member;
+    }
+
+    private void mockPresidentPermission(Club club) {
+        ClubMember president = createPresidentMember(club);
+        given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                .willReturn(Optional.of(president));
+    }
+
+    @Nested
+    @DisplayName("createRole - 역할 생성")
+    class CreateRole {
+
+        @Test
+        @DisplayName("성공: 회장이 커스텀 역할 생성")
+        void success() {
+            Club club = createClub();
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.existsByClubIdAndName(CLUB_ID, "홍보담당")).willReturn(false);
+            given(clubRoleRepository.save(any(ClubRole.class)))
+                    .willAnswer(invocation -> {
+                        ClubRole r = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(r, "id", 10L);
+                        return r;
+                    });
+
+            CreateClubRoleParam param = new CreateClubRoleParam(
+                    "홍보담당", List.of("MANAGE_NOTICE", "MANAGE_FEED"), true);
+
+            ClubRoleResult result = clubRoleService.createRole(USER_ID, CLUB_ID, param);
+
+            assertThat(result.id()).isEqualTo(10L);
+            assertThat(result.name()).isEqualTo("홍보담당");
+            assertThat(result.permissions()).containsExactlyInAnyOrder("MANAGE_NOTICE", "MANAGE_FEED");
+            assertThat(result.isStaff()).isTrue();
+            assertThat(result.isDefault()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 9번 권한(MANAGE_MEMBER) 보유자가 역할 생성")
+        void successByMemberManager() {
+            Club club = createClub();
+            ClubRole managerRole = ClubRole.builder()
+                    .club(club).name("인사팀장")
+                    .permissions(Permission.combine(Permission.MANAGE_MEMBER))
+                    .isStaff(true).isDefault(false).build();
+            ReflectionTestUtils.setField(managerRole, "id", 5L);
+            ClubMember manager = ClubMember.builder()
+                    .club(club).user(createUser(2L)).role(managerRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(manager, "id", 51L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, 2L))
+                    .willReturn(Optional.of(manager));
+            given(clubRoleRepository.existsByClubIdAndName(CLUB_ID, "신규역할")).willReturn(false);
+            given(clubRoleRepository.save(any(ClubRole.class)))
+                    .willAnswer(invocation -> {
+                        ClubRole r = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(r, "id", 11L);
+                        return r;
+                    });
+
+            CreateClubRoleParam param = new CreateClubRoleParam("신규역할", List.of(), false);
+
+            ClubRoleResult result = clubRoleService.createRole(2L, CLUB_ID, param);
+
+            assertThat(result.id()).isEqualTo(11L);
+            assertThat(result.name()).isEqualTo("신규역할");
+        }
+
+        @Test
+        @DisplayName("실패: 중복된 역할 이름")
+        void failDuplicateName() {
+            Club club = createClub();
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.existsByClubIdAndName(CLUB_ID, "회장")).willReturn(true);
+
+            CreateClubRoleParam param = new CreateClubRoleParam("회장", List.of(), false);
+
+            assertThatThrownBy(() -> clubRoleService.createRole(USER_ID, CLUB_ID, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ROLE_NAME_DUPLICATED));
+        }
+
+        @Test
+        @DisplayName("실패: 멤버가 아닌 유저")
+        void failNotMember() {
+            Club club = createClub();
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, 999L))
+                    .willReturn(Optional.empty());
+
+            CreateClubRoleParam param = new CreateClubRoleParam("역할", List.of(), false);
+
+            assertThatThrownBy(() -> clubRoleService.createRole(999L, CLUB_ID, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.NOT_CLUB_MEMBER));
+        }
+
+        @Test
+        @DisplayName("실패: 권한 없는 멤버 (부원)")
+        void failPermissionDenied() {
+            Club club = createClub();
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            ClubMember member = ClubMember.builder()
+                    .club(club).user(createUser(USER_ID)).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(member, "id", 51L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                    .willReturn(Optional.of(member));
+
+            CreateClubRoleParam param = new CreateClubRoleParam("역할", List.of(), false);
+
+            assertThatThrownBy(() -> clubRoleService.createRole(USER_ID, CLUB_ID, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ROLE_MANAGE_FORBIDDEN));
+        }
+    }
+
+    @Nested
+    @DisplayName("getRoles - 역할 목록 조회")
+    class GetRoles {
+
+        @Test
+        @DisplayName("성공: 역할 목록 조회")
+        void success() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            ClubRole customRole = ClubRole.builder()
+                    .club(club).name("홍보담당")
+                    .permissions(Permission.combine(Permission.MANAGE_NOTICE, Permission.MANAGE_FEED))
+                    .isStaff(true).isDefault(false).build();
+            ReflectionTestUtils.setField(customRole, "id", 10L);
+
+            given(clubRepository.existsById(CLUB_ID)).willReturn(true);
+            given(clubRoleRepository.findByClubId(CLUB_ID))
+                    .willReturn(List.of(presidentRole, customRole));
+
+            List<ClubRoleResult> results = clubRoleService.getRoles(CLUB_ID);
+
+            assertThat(results).hasSize(2);
+            assertThat(results.get(0).name()).isEqualTo("회장");
+            assertThat(results.get(0).isDefault()).isTrue();
+            assertThat(results.get(1).name()).isEqualTo("홍보담당");
+            assertThat(results.get(1).isDefault()).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 동아리")
+        void failNotFound() {
+            given(clubRepository.existsById(999L)).willReturn(false);
+
+            assertThatThrownBy(() -> clubRoleService.getRoles(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.CLUB_NOT_FOUND));
+        }
+    }
+}

--- a/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubRoleServiceTest.java
@@ -201,6 +201,130 @@ class ClubRoleServiceTest {
     }
 
     @Nested
+    @DisplayName("updateRole - 역할 수정")
+    class UpdateRole {
+
+        private ClubRole createCustomRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("홍보담당")
+                    .permissions(Permission.combine(Permission.MANAGE_NOTICE, Permission.MANAGE_FEED))
+                    .isStaff(true).isDefault(false).build();
+            ReflectionTestUtils.setField(role, "id", 10L);
+            return role;
+        }
+
+        @Test
+        @DisplayName("성공: 커스텀 역할 수정")
+        void successCustomRole() {
+            Club club = createClub();
+            ClubRole role = createCustomRole(club);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.findById(10L)).willReturn(Optional.of(role));
+            given(clubRoleRepository.existsByClubIdAndName(CLUB_ID, "수정된역할")).willReturn(false);
+
+            UpdateClubRoleParam param = new UpdateClubRoleParam(
+                    "수정된역할", List.of("MANAGE_CALENDAR"), false);
+
+            ClubRoleResult result = clubRoleService.updateRole(USER_ID, CLUB_ID, 10L, param);
+
+            assertThat(result.name()).isEqualTo("수정된역할");
+            assertThat(result.permissions()).containsExactly("MANAGE_CALENDAR");
+            assertThat(result.isStaff()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 회장이 기본 역할(부회장) 수정")
+        void successDefaultRoleByPresident() {
+            Club club = createClub();
+            ClubRole viceRole = ClubRole.builder()
+                    .club(club).name("부회장").permissions(0L)
+                    .isStaff(true).isDefault(true).build();
+            ReflectionTestUtils.setField(viceRole, "id", 2L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubRoleRepository.findById(2L)).willReturn(Optional.of(viceRole));
+            // validatePresident
+            ClubMember president = createPresidentMember(club);
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, USER_ID))
+                    .willReturn(Optional.of(president));
+
+            UpdateClubRoleParam param = new UpdateClubRoleParam(
+                    "부회장", List.of("MANAGE_NOTICE"), true);
+
+            ClubRoleResult result = clubRoleService.updateRole(USER_ID, CLUB_ID, 2L, param);
+
+            assertThat(result.permissions()).containsExactly("MANAGE_NOTICE");
+        }
+
+        @Test
+        @DisplayName("실패: 회장 역할 수정 시도 (불변)")
+        void failPresidentRole() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubRoleRepository.findById(1L)).willReturn(Optional.of(presidentRole));
+
+            UpdateClubRoleParam param = new UpdateClubRoleParam("변경", List.of(), false);
+
+            assertThatThrownBy(() -> clubRoleService.updateRole(USER_ID, CLUB_ID, 1L, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.PRESIDENT_ROLE_NOT_MODIFIABLE));
+        }
+
+        @Test
+        @DisplayName("실패: 이름 변경 시 중복")
+        void failDuplicateName() {
+            Club club = createClub();
+            ClubRole role = createCustomRole(club);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            mockPresidentPermission(club);
+            given(clubRoleRepository.findById(10L)).willReturn(Optional.of(role));
+            given(clubRoleRepository.existsByClubIdAndName(CLUB_ID, "부회장")).willReturn(true);
+
+            UpdateClubRoleParam param = new UpdateClubRoleParam("부회장", List.of(), false);
+
+            assertThatThrownBy(() -> clubRoleService.updateRole(USER_ID, CLUB_ID, 10L, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ROLE_NAME_DUPLICATED));
+        }
+
+        @Test
+        @DisplayName("실패: 기본 역할을 회장이 아닌 유저가 수정")
+        void failDefaultRoleByNonPresident() {
+            Club club = createClub();
+            ClubRole viceRole = ClubRole.builder()
+                    .club(club).name("부회장").permissions(0L)
+                    .isStaff(true).isDefault(true).build();
+            ReflectionTestUtils.setField(viceRole, "id", 2L);
+
+            ClubRole managerRole = ClubRole.builder()
+                    .club(club).name("인사팀장")
+                    .permissions(Permission.combine(Permission.MANAGE_MEMBER))
+                    .isStaff(true).isDefault(false).build();
+            ReflectionTestUtils.setField(managerRole, "id", 5L);
+            ClubMember manager = ClubMember.builder()
+                    .club(club).user(createUser(2L)).role(managerRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(manager, "id", 51L);
+
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubRoleRepository.findById(2L)).willReturn(Optional.of(viceRole));
+            given(clubMemberRepository.findByClubIdAndUserId(CLUB_ID, 2L))
+                    .willReturn(Optional.of(manager));
+
+            UpdateClubRoleParam param = new UpdateClubRoleParam("부회장", List.of(), true);
+
+            assertThatThrownBy(() -> clubRoleService.updateRole(2L, CLUB_ID, 2L, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.DEFAULT_ROLE_MODIFY_FORBIDDEN));
+        }
+    }
+
+    @Nested
     @DisplayName("getRoles - 역할 목록 조회")
     class GetRoles {
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
@@ -588,6 +588,49 @@ class ClubServiceTest {
     }
 
     @Nested
+    @DisplayName("processGraduation - 자동 수료 처리")
+    class ProcessGraduation {
+
+        @Test
+        @DisplayName("성공: 활동 종료일 지난 ACTIVE 멤버 수료 처리")
+        void success() {
+            Club club = createClub();
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+
+            ClubMember expired = ClubMember.builder()
+                    .club(club).user(createUser()).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE)
+                    .activityEndDate(LocalDate.now().minusDays(1))
+                    .build();
+            ReflectionTestUtils.setField(expired, "id", 60L);
+
+            given(clubMemberRepository.findByActivityStatusAndActivityEndDateLessThanEqual(
+                    eq(ActivityStatus.ACTIVE), any(LocalDate.class)))
+                    .willReturn(List.of(expired));
+
+            int count = clubService.processGraduation();
+
+            assertThat(count).isEqualTo(1);
+            assertThat(expired.getActivityStatus()).isEqualTo(ActivityStatus.GRADUATED);
+        }
+
+        @Test
+        @DisplayName("성공: 수료 대상 없음")
+        void successNoTargets() {
+            given(clubMemberRepository.findByActivityStatusAndActivityEndDateLessThanEqual(
+                    eq(ActivityStatus.ACTIVE), any(LocalDate.class)))
+                    .willReturn(List.of());
+
+            int count = clubService.processGraduation();
+
+            assertThat(count).isEqualTo(0);
+        }
+    }
+
+    @Nested
     @DisplayName("getMembers - 동아리 회원 목록 조회")
     class GetMembers {
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
@@ -99,7 +99,7 @@ class ClubServiceTest {
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(createUser()));
             given(clubMemberRepository.findByUserIdAndStatusAndActivityStatus(
                     USER_ID, BaseStatus.ACTIVE, ActivityStatus.ACTIVE)).willReturn(List.of());
-            given(clubRepository.save(any(Club.class))).willAnswer(invocation -> {
+            given(clubRepository.<Club>save(any(Club.class))).willAnswer(invocation -> {
                 Club club = invocation.getArgument(0);
                 ReflectionTestUtils.setField(club, "id", 100L);
                 return club;
@@ -269,6 +269,75 @@ class ClubServiceTest {
             Slice<ClubSummaryResult> result = clubService.getClubList(param);
 
             assertThat(result.getContent()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getMembers - 동아리 회원 목록 조회")
+    class GetMembers {
+
+        private ClubRole createPresidentRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("회장").permissions(Permission.all())
+                    .isStaff(true).isDefault(true).build();
+            ReflectionTestUtils.setField(role, "id", 1L);
+            return role;
+        }
+
+        @Test
+        @DisplayName("성공: 전체 멤버 조회")
+        void successAll() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            ClubMember president = ClubMember.builder()
+                    .club(club).user(club.getCreator()).role(presidentRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(president, "id", 50L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubId(100L)).willReturn(List.of(president));
+
+            List<ClubMemberResult> results = clubService.getMembers(USER_ID, 100L, null);
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).roleName()).isEqualTo("회장");
+        }
+
+        @Test
+        @DisplayName("성공: 상태별 필터 조회")
+        void successFiltered() {
+            Club club = createClub();
+            ClubRole presidentRole = createPresidentRole(club);
+            ClubMember president = ClubMember.builder()
+                    .club(club).user(club.getCreator()).role(presidentRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(president, "id", 50L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndActivityStatus(100L, ActivityStatus.GUEST))
+                    .willReturn(List.of());
+
+            List<ClubMemberResult> results = clubService.getMembers(USER_ID, 100L, ActivityStatus.GUEST);
+
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        @DisplayName("실패: 멤버가 아닌 유저")
+        void failNotMember() {
+            Club club = createClub();
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, 999L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubService.getMembers(999L, 100L, null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.NOT_CLUB_MEMBER));
         }
     }
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
@@ -1,6 +1,7 @@
 package com.dewple.club.service;
 
 import com.dewple.club.entity.ClubDeletionVote;
+import com.dewple.club.entity.ClubGeneration;
 import com.dewple.club.entity.ClubMember;
 import com.dewple.club.entity.ClubRole;
 import com.dewple.club.exception.ClubErrorCode;
@@ -60,6 +61,7 @@ class ClubServiceTest {
     @Mock private RegionRepository regionRepository;
     @Mock private ClubRecruitmentPort clubRecruitmentPort;
     @Mock private ClubDeletionVoteRepository clubDeletionVoteRepository;
+    @Mock private ClubGenerationRepository clubGenerationRepository;
 
     @InjectMocks
     private ClubService clubService;
@@ -269,6 +271,188 @@ class ClubServiceTest {
             Slice<ClubSummaryResult> result = clubService.getClubList(param);
 
             assertThat(result.getContent()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("inviteGuest - 외부인 GUEST 초대")
+    class InviteGuest {
+
+        private ClubRole createPresidentRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("회장").permissions(Permission.all())
+                    .isStaff(true).isDefault(true).build();
+            ReflectionTestUtils.setField(role, "id", 1L);
+            return role;
+        }
+
+        private ClubMember createPresidentMember(Club club) {
+            ClubRole role = createPresidentRole(club);
+            ClubMember member = ClubMember.builder()
+                    .club(club).user(club.getCreator()).role(role)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(member, "id", 50L);
+            return member;
+        }
+
+        @Test
+        @DisplayName("성공: GUEST 초대")
+        void success() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+            User guestUser = User.builder().userId("guest").name("게스트").phone("010").build();
+            ReflectionTestUtils.setField(guestUser, "id", 5L);
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, 5L))
+                    .willReturn(Optional.empty());
+            given(userRepository.findById(5L)).willReturn(Optional.of(guestUser));
+            given(clubRoleRepository.findByClubIdAndName(100L, "부원"))
+                    .willReturn(Optional.of(memberRole));
+            given(clubMemberRepository.save(any(ClubMember.class)))
+                    .willAnswer(invocation -> {
+                        ClubMember m = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(m, "id", 60L);
+                        return m;
+                    });
+
+            InviteGuestParam param = new InviteGuestParam(5L, List.of(1L));
+            ClubMemberResult result = clubService.inviteGuest(USER_ID, 100L, param);
+
+            assertThat(result.activityStatus()).isEqualTo(ActivityStatus.GUEST);
+            assertThat(result.roleName()).isEqualTo("부원");
+        }
+
+        @Test
+        @DisplayName("실패: 이미 멤버인 유저 초대")
+        void failAlreadyMember() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, 5L))
+                    .willReturn(Optional.of(mock(ClubMember.class)));
+
+            InviteGuestParam param = new InviteGuestParam(5L, List.of(1L));
+
+            assertThatThrownBy(() -> clubService.inviteGuest(USER_ID, 100L, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ALREADY_CLUB_MEMBER));
+        }
+
+        @Test
+        @DisplayName("실패: 모임 미지정")
+        void failNoActivity() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+
+            InviteGuestParam param = new InviteGuestParam(5L, List.of());
+
+            assertThatThrownBy(() -> clubService.inviteGuest(USER_ID, 100L, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.ACTIVITY_ID_REQUIRED));
+        }
+    }
+
+    @Nested
+    @DisplayName("promoteToMember - GUEST→MEMBER 승격")
+    class PromoteToMember {
+
+        private ClubRole createPresidentRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("회장").permissions(Permission.all())
+                    .isStaff(true).isDefault(true).build();
+            ReflectionTestUtils.setField(role, "id", 1L);
+            return role;
+        }
+
+        private ClubMember createPresidentMember(Club club) {
+            ClubRole role = createPresidentRole(club);
+            ClubMember member = ClubMember.builder()
+                    .club(club).user(club.getCreator()).role(role)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(member, "id", 50L);
+            return member;
+        }
+
+        @Test
+        @DisplayName("성공: GUEST를 MEMBER로 승격")
+        void success() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+
+            User guestUser = User.builder().userId("guest").name("게스트").phone("010").build();
+            ReflectionTestUtils.setField(guestUser, "id", 5L);
+            ClubMember guest = ClubMember.builder()
+                    .club(club).user(guestUser).role(memberRole)
+                    .activityStatus(ActivityStatus.GUEST).build();
+            ReflectionTestUtils.setField(guest, "id", 60L);
+
+            ClubGeneration generation = ClubGeneration.builder()
+                    .club(club).generationNo(1)
+                    .startDate(LocalDate.of(2026, 3, 1)).endDate(LocalDate.of(2026, 12, 31))
+                    .build();
+            ReflectionTestUtils.setField(generation, "id", 10L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndId(100L, 60L))
+                    .willReturn(Optional.of(guest));
+            given(clubGenerationRepository.findById(10L)).willReturn(Optional.of(generation));
+
+            PromoteToMemberParam param = new PromoteToMemberParam(10L, LocalDate.of(2026, 12, 31));
+            clubService.promoteToMember(USER_ID, 100L, 60L, param);
+
+            assertThat(guest.getActivityStatus()).isEqualTo(ActivityStatus.ACTIVE);
+            assertThat(guest.getJoinGeneration()).isEqualTo(generation);
+            assertThat(guest.getActivityEndDate()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("실패: GUEST가 아닌 멤버 승격 시도")
+        void failNotGuest() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            ClubMember activeMember = ClubMember.builder()
+                    .club(club).user(createUser()).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(activeMember, "id", 60L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndId(100L, 60L))
+                    .willReturn(Optional.of(activeMember));
+
+            PromoteToMemberParam param = new PromoteToMemberParam(10L, LocalDate.of(2026, 12, 31));
+
+            assertThatThrownBy(() -> clubService.promoteToMember(USER_ID, 100L, 60L, param))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.NOT_GUEST_STATUS));
         }
     }
 

--- a/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
+++ b/modules/club/src/test/java/com/dewple/club/service/ClubServiceTest.java
@@ -2,6 +2,7 @@ package com.dewple.club.service;
 
 import com.dewple.club.entity.ClubDeletionVote;
 import com.dewple.club.entity.ClubGeneration;
+import com.dewple.club.entity.ClubKickVote;
 import com.dewple.club.entity.ClubMember;
 import com.dewple.club.entity.ClubRole;
 import com.dewple.club.exception.ClubErrorCode;
@@ -62,6 +63,7 @@ class ClubServiceTest {
     @Mock private ClubRecruitmentPort clubRecruitmentPort;
     @Mock private ClubDeletionVoteRepository clubDeletionVoteRepository;
     @Mock private ClubGenerationRepository clubGenerationRepository;
+    @Mock private ClubKickVoteRepository clubKickVoteRepository;
 
     @InjectMocks
     private ClubService clubService;
@@ -453,6 +455,135 @@ class ClubServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ClubErrorCode.NOT_GUEST_STATUS));
+        }
+    }
+
+    @Nested
+    @DisplayName("requestKick - 회원 내보내기 신청")
+    class RequestKick {
+
+        private ClubRole createPresidentRole(Club club) {
+            ClubRole role = ClubRole.builder()
+                    .club(club).name("회장").permissions(Permission.all())
+                    .isStaff(true).isDefault(true).build();
+            ReflectionTestUtils.setField(role, "id", 1L);
+            return role;
+        }
+
+        private ClubMember createPresidentMember(Club club) {
+            ClubRole role = createPresidentRole(club);
+            ClubMember member = ClubMember.builder()
+                    .club(club).user(club.getCreator()).role(role)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(member, "id", 50L);
+            return member;
+        }
+
+        @Test
+        @DisplayName("성공: 권한자 1명 → 즉시 내보내기")
+        void successSingleVoter() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            User targetUser = User.builder().userId("target").name("대상").phone("010").build();
+            ReflectionTestUtils.setField(targetUser, "id", 2L);
+            ClubMember target = ClubMember.builder()
+                    .club(club).user(targetUser).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(target, "id", 60L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndId(100L, 60L))
+                    .willReturn(Optional.of(target));
+            given(clubKickVoteRepository.existsByTargetMember(target)).willReturn(false);
+            given(clubMemberRepository.findByClubIdAndStatusAndActivityStatus(
+                    100L, BaseStatus.ACTIVE, ActivityStatus.ACTIVE))
+                    .willReturn(List.of(president));
+
+            clubService.requestKick(USER_ID, 100L, 60L);
+
+            assertThat(target.getActivityStatus()).isEqualTo(ActivityStatus.KICKEDOUT);
+        }
+
+        @Test
+        @DisplayName("실패: 이미 내보내기 투표 진행 중")
+        void failAlreadyInProgress() {
+            Club club = createClub();
+            ClubMember president = createPresidentMember(club);
+            ClubMember target = mock(ClubMember.class);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(president));
+            given(clubMemberRepository.findByClubIdAndId(100L, 60L))
+                    .willReturn(Optional.of(target));
+            given(clubKickVoteRepository.existsByTargetMember(target)).willReturn(true);
+
+            assertThatThrownBy(() -> clubService.requestKick(USER_ID, 100L, 60L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ClubErrorCode.KICK_ALREADY_IN_PROGRESS));
+        }
+    }
+
+    @Nested
+    @DisplayName("voteKick - 회원 내보내기 투표")
+    class VoteKick {
+
+        @Test
+        @DisplayName("성공: 동의 → 전원 동의 → 내보내기 완료")
+        void successAllApproved() {
+            Club club = createClub();
+            ClubRole memberRole = ClubRole.builder()
+                    .club(club).name("부원").permissions(0L)
+                    .isStaff(false).isDefault(true).build();
+            ReflectionTestUtils.setField(memberRole, "id", 5L);
+            User targetUser = User.builder().userId("target").name("대상").phone("010").build();
+            ReflectionTestUtils.setField(targetUser, "id", 2L);
+            ClubMember target = ClubMember.builder()
+                    .club(club).user(targetUser).role(memberRole)
+                    .activityStatus(ActivityStatus.ACTIVE).build();
+            ReflectionTestUtils.setField(target, "id", 60L);
+
+            ClubKickVote vote = ClubKickVote.builder()
+                    .club(club).targetMember(target).voter(createUser()).isApproved(null).build();
+            ReflectionTestUtils.setField(vote, "id", 1L);
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndId(100L, 60L)).willReturn(Optional.of(target));
+            given(clubKickVoteRepository.existsByTargetMember(target)).willReturn(true);
+            given(clubKickVoteRepository.findByTargetMemberAndVoterId(target, USER_ID))
+                    .willReturn(Optional.of(vote));
+            given(clubKickVoteRepository.findByTargetMember(target)).willReturn(List.of(vote));
+
+            clubService.voteKick(USER_ID, 100L, 60L, true);
+
+            assertThat(vote.getIsApproved()).isTrue();
+            assertThat(target.getActivityStatus()).isEqualTo(ActivityStatus.KICKEDOUT);
+        }
+
+        @Test
+        @DisplayName("성공: 거부 → 투표 종료")
+        void successRejected() {
+            Club club = createClub();
+            ClubMember target = mock(ClubMember.class);
+            ClubKickVote vote = ClubKickVote.builder()
+                    .club(club).targetMember(target).voter(createUser()).isApproved(null).build();
+
+            given(clubRepository.findById(100L)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubIdAndId(100L, 60L)).willReturn(Optional.of(target));
+            given(clubKickVoteRepository.existsByTargetMember(target)).willReturn(true);
+            given(clubKickVoteRepository.findByTargetMemberAndVoterId(target, USER_ID))
+                    .willReturn(Optional.of(vote));
+
+            clubService.voteKick(USER_ID, 100L, 60L, false);
+
+            then(clubKickVoteRepository).should().deleteByTargetMember(target);
         }
     }
 


### PR DESCRIPTION
## 📝 요약

- resolved #38 

## 🔖 변경 사항

### 동아리 기본 API

| 항목 | 내용 |                                                                                                                                      
|------|------|
| 생성 | 이름/본인인증필수/카테고리/지역/활동방식, 기본 역할 5종 자동 생성, 회장 동시 운영 최대 5개 |                                                
| 조회 | 목록 조회 (필터 + 부원+좋아요 합산순 정렬), 단건 조회 (기본 정보 + 소개페이지) |                                                            
| 수정 | 이름/설명/커버이미지/활동방식/카테고리/지역 변경 (3번 권한 검증) |                                                                          
| 설정 변경 | 본인인증 필수/연령대/성별 태그 변경, 활성 공고 있을 때 변경 불가 |                                                                     
| 삭제 | 11번 권한자 전원 동의 투표, 1일 유예 → hard delete, 제재 삭제 취소 불가 |                                                                   
                                                                                                                                                   
### 역할/권한                                                                                                                                        
                                                        
| 항목 | 내용 |                                                                                                                                      
|------|------|                                           
| 역할 CRUD | 비트마스크 기반 18종 권한, 생성 시 기본 역할 5종 자동 생성 (회장/부회장/인사/홍보/부원) |
| 역할 할당 | 멤버에 역할 부여, 회장 역할 직접 할당 불가 |                                                                                           
| 회장 위임 | 회장만 가능, 기존 회장 → 부원 강등 + 대상 → 회장 승격 |                                                                                
                                                                                                                                                   
### 회원 관리                                                                                                                                        
                                                                                                                                                   
| 항목 | 내용 |                                           
|------|------|
| 회원 목록 조회 | 상태별(GUEST/MEMBER/GRADUATED/KICKED) 필터 |
| 외부인 초대 | GUEST로 초대 (모임 연결 필수) |                                                                                                      
| GUEST→MEMBER 승격 | 활동 기한 명시 필수 |                                                                                                          
| 회원 내보내기 | 9번 권한자 전원 동의 (응답 기한 1일, 미응답 시 자동 승인) |                                                                        
| 수료 처리 | 활동 종료일까지 내보내기 안 되면 자동 GRADUATED |                                                                                      
                                                                                                                                                   
### 리팩토링                                                                                                                                         
                                                                                                                                                   
| 항목 | 내용 |                                           
|------|------|
| 의존성 정리 | 공통 Repository를 common으로 이동, 도메인 모듈 간 불필요한 의존 제거 |
| 에러코드 | CommonErrorCode 추가, 중복 삭제, 전체 도메인 넘버링 순차 정리 |                                                                         
| Swagger | 태그 도메인별 그룹화 + 순서 지정 |   

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
